### PR TITLE
update digital centre cta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated background image for splash page
 - Updated metadata social media image for splash page
 - Removed cookie redirects based on language
+- Updated cta banner on digital centre page and removed feedback reference
 
 ## Fixed
 

--- a/pages/projects/digital-centre.js
+++ b/pages/projects/digital-centre.js
@@ -5,7 +5,6 @@ import { useTranslation } from "next-i18next";
 import { Layout } from "../../components/organisms/Layout";
 import { CallToAction } from "../../components/molecules/CallToAction";
 import { useEffect, useState } from "react";
-import FeedbackWidget from "../../components/molecules/FeedbackWidget";
 import aemServiceInstance from "../../services/aemServiceInstance";
 import Image from "next/image";
 
@@ -34,17 +33,12 @@ ThumbnailWithCaption.propTypes = {
 
 export default function DigitalCenter(props) {
   const { t } = useTranslation(["common", "dc"]);
-  const [showFeedback, setShowFeedback] = useState(false);
   const [pageData] = useState(props.pageData.item);
 
   let path =
     typeof window !== "undefined" && window.location.origin
       ? window.location.href
       : "";
-
-  let toggleForm = async (e) => {
-    setShowFeedback(!showFeedback);
-  };
 
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
@@ -55,12 +49,6 @@ export default function DigitalCenter(props) {
 
   return (
     <>
-      <FeedbackWidget
-        showFeedback={showFeedback}
-        toggleForm={toggleForm}
-        projectName={t("dc:OverviewTitle")}
-        path={path}
-      />
       <Layout
         locale={props.locale}
         langUrl={
@@ -70,7 +58,6 @@ export default function DigitalCenter(props) {
           { text: t("siteTitle"), link: t("breadCrumbsHref1") },
           { text: t("menuLink1"), link: t("breadCrumbsHref2") },
         ]}
-        feedbackActive={true}
         projectName={t("dc:OverviewTitle")}
       >
         <Head>
@@ -828,14 +815,12 @@ export default function DigitalCenter(props) {
         </section>
 
         <CallToAction
-          title={t("giveFeedback")}
-          html={t("bottomFeedbackDescription")}
+          title={t("signupHomeButton")}
+          description={t("signupBannerDescription")}
+          disclaimer={t("signupBannerDisclaimer")}
           lang={props.locale}
-          href=""
-          hrefText={t("bottomFeedbackBtn")}
-          feedbackActive={true}
-          clicked={() => setShowFeedback(true)}
-          ariaExpanded={showFeedback.toString()}
+          href={t("signupInfoRedirect")}
+          hrefText={t("signupBannerBtnText")}
         />
       </Layout>
       {props.adobeAnalyticsUrl ? (

--- a/pages/projects/digital-centre.js
+++ b/pages/projects/digital-centre.js
@@ -35,11 +35,6 @@ export default function DigitalCenter(props) {
   const { t } = useTranslation(["common", "dc"]);
   const [pageData] = useState(props.pageData.item);
 
-  let path =
-    typeof window !== "undefined" && window.location.origin
-      ? window.location.href
-      : "";
-
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];


### PR DESCRIPTION
# Description

[Update CTA on digital Centre overview page ](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=73740)

Just a small update to the CTA banner on the digital centre page. I have removed all the referece to the feedback widget, the CTA banner should be the same as the one on the /projects page. 

## Test Instructions

1. yarn dev
2. visit /projects/digital-centre
3. check the cta banner

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
