### PR TITLE
Having a Child CTA

### DIFF
--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -326,12 +326,13 @@ export default function LifeJourneys(props) {
             </strong>
           </p>
         </section>
-
         <CallToAction
-          title={t("signupTitleCallToAction")}
-          html={t("becomeAParticipantDescription")}
-          href={"/signup"}
-          hrefText={t("signupBtn")}
+          title={t("signupHomeButton")}
+          description={t("signupBannerDescription")}
+          disclaimer={t("signupBannerDisclaimer")}
+          lang={props.locale}
+          href={t("signupInfoRedirect")}
+          hrefText={t("signupBannerBtnText")}
         />
       </Layout>
       {props.adobeAnalyticsUrl ? (


### PR DESCRIPTION
# Description

[DEV: Remove "unsubscribe" link from sign-up CtA](https://dev.azure.com/VP-BD/DECD/_sprints/taskboard/Service%20Canada%20Labs/DECD/Service%20Canada%20Labs/SCL%20Sprint%201?workitem=75726)

Remove unsubscribe link on the cta on Having a Child page

## Acceptance Criteria

Signup banner on having a child page should be the same as the one on /projects. Unsubscribe link is removed.

## Test Instructions

1. yarn dev
2. visit /projects/life-journey
3. check the signup banner/cta

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
