### PR TITLE
Update VA overview page image

### DIFF
--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -11,7 +11,7 @@ export function ProjectInfo(props) {
 
   return (
     <>
-      <div className="p-4 grid grid-cols-4 gap-x-6">
+      <div className="grid grid-cols-4">
         <strong className="col-span-1">{t("started")}</strong>
         <p className="col-span-3">{props.dateStarted.substring(0, 10)}</p>
         <strong className="col-span-1">{t("ended")}</strong>

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -114,75 +114,71 @@ export default function Home(props) {
         </Head>
 
         {/* Virtual Assitant Demo section start -  with link to working prototype */}
-        <section className="layout-container mb-10">
-          <h1 className="mb-16 text-h1l" tabIndex="-1" id="pageMainTitle">
-            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
-          </h1>
-          <div>
-            <div className="flex flex-col break-words lg:grid lg:grid-cols-2 gap-4 lg:gap-6 ">
-              <div>
-                <h2 className="mb-0 text-h1" id="virtualAssistantTitle">
-                  {props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[0].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[0].content[0]
-                        .value}
-                </h2>
-                <p className="pt-8">
-                  {props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[1].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[1].content[0]
-                        .value}
-                </p>
-                <ProjectInfo
-                  stage={
-                    props.locale === "en"
-                      ? pageData.scFragments[5].scContentEn.json[0].content[0]
-                          .value
-                      : pageData.scFragments[5].scContentFr.json[0].content[0]
-                          .value
-                  }
-                  info={
-                    props.locale === "en"
-                      ? pageData.scFragments[5].scContentEn.json[0].content[1]
-                          .value
-                      : pageData.scFragments[5].scContentFr.json[0].content[1]
-                          .value
-                  }
-                  dateStarted={pageData.scFragments[1].dateStarted}
-                  dateEnded={pageData.scFragments[1].dateEnded}
-                  projectStage={
-                    props.locale === "en"
-                      ? pageData.scFragments[1].projectStageEn
-                      : pageData.scFragments[1].projectStageFr
-                  }
-                  status={
-                    props.locale === "en"
-                      ? pageData.scFragments[1].statusEn
-                      : pageData.scFragments[1].statusFr
-                  }
-                />
-              </div>
+        <section className="layout-container my-8">
+          <div className="flex flex-col break-words lg:grid lg:grid-cols-2 gap-4 lg:gap-6">
+            <h1
+              className="text-h1 border-h1-red-bar"
+              tabIndex="-1"
+              id="pageMainTitle"
+            >
+              {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
+            </h1>
+            <div className="row-span-4 p-0 mx-4">
               <div className="flex justify-center">
-                <img
-                  src={
-                    props.locale === "en"
-                      ? pageData.scFragments[2].scImageEn._publishUrl
-                      : pageData.scFragments[2].scImageFr._publishUrl
-                  }
-                  alt={
-                    props.locale === "en"
-                      ? pageData.scFragments[2].scImageAltTextEn
-                      : pageData.scFragments[2].scImageAltTextFr
-                  }
-                  width={591}
-                  height={502}
-                />
+                <div className="object-fill h-auto w-auto max-w-450px">
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[2].scImageEn._publishUrl
+                        : pageData.scFragments[2].scImageFr._publishUrl
+                    }
+                    alt={
+                      props.locale === "en"
+                        ? pageData.scFragments[2].scImageAltTextEn
+                        : pageData.scFragments[2].scImageAltTextFr
+                    }
+                    width={468}
+                    height={462}
+                  />
+                </div>
               </div>
             </div>
+            <h2 className="mb-0 text-h1" id="virtualAssistantTitle">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[0].content[0].value
+                : pageData.scFragments[0].scContentFr.json[0].content[0].value}
+            </h2>
+            <p className="font-body text-lg">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[1].content[0].value
+                : pageData.scFragments[0].scContentFr.json[1].content[0].value}
+            </p>
+            <ProjectInfo
+              stage={
+                props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+                  : pageData.scFragments[5].scContentFr.json[0].content[0].value
+              }
+              info={
+                props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[0].content[1].value
+                  : pageData.scFragments[5].scContentFr.json[0].content[1].value
+              }
+              dateStarted={pageData.scFragments[1].dateStarted}
+              dateEnded={pageData.scFragments[1].dateEnded}
+              projectStage={
+                props.locale === "en"
+                  ? pageData.scFragments[1].projectStageEn
+                  : pageData.scFragments[1].projectStageFr
+              }
+              status={
+                props.locale === "en"
+                  ? pageData.scFragments[1].statusEn
+                  : pageData.scFragments[1].statusFr
+              }
+            />
           </div>
-          <div className="mb-12">
+          <div className="my-8">
             <h2>
               {props.locale === "en"
                 ? pageData.scFragments[0].scContentEn.json[2].content[0].value


### PR DESCRIPTION
# Description

Adjust the bot image on Virtual assistant overview page.

These changes came back from Nelia:
- The image should be responsive like the one on the Try it out page
- The image should align horizontally with the page title, not the content
- In the mobile view, on the Try it out page the image is positioned right after the title, but on the overview page the image is positioned below the content. The image should be positioned below the title as well

## Acceptance Criteria

The virtual assistant overview page should match the design on [Figma](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?node-id=11332%3A29306)

## Test instructions

1. yarn dev
2. visit /projects/virtual-assistant

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
