### PR TITLE
adjust splash page image, align footer with content

### DIFF
--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -10,14 +10,14 @@ export function Footer(props) {
     <div className="w-full">
       <div className="w-full h-auto footerBackground bg-custom-blue-dark">
         <div
-          className="py-7 layout-container"
+          className="w-full py-7 layout-container"
           role="navigation"
           aria-labelledby="footerNav1"
         >
           <h3 className="sr-only" id="footerNav1">
             {props.footerNav1}
           </h3>
-          <ul className="flex flex-col text-xs lg:grid lg:grid-cols-2 xl:grid xl:grid-cols-3 lg:gap-1">
+          <ul className="flex flex-col text-xs lg:grid lg:grid-cols-2 xl:grid xl:grid-cols-3 lg:gap-1 -ml-4">
             {" "}
             {props.footerBoxLinks.map((value, index) => {
               return (
@@ -44,7 +44,7 @@ export function Footer(props) {
             <h3 className="sr-only" id="footerNav2">
               {props.footerNav2}
             </h3>
-            <ul className="flex flex-col md:grid md:grid-cols-2 xl:flex lg:flex-row">
+            <ul className="flex flex-col md:grid md:grid-cols-2 xl:flex lg:flex-row -ml-4">
               {props.links.map((value, index) => {
                 return (
                   <li

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ export default function Index(props) {
 
   return (
     <>
-      <div className="splash-image bg-splash-img-mobile xs:bg-splash-img bg-no-repeat h-screen min-w-300px min-h-screen" />
+      <div className="splash-bg splash-image bg-splash-img-mobile xs:bg-splash-img bg-no-repeat h-screen min-w-300px min-h-screen" />
       <Head>
         {props.adobeAnalyticsUrl ? (
           <script src={props.adobeAnalyticsUrl} />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -119,6 +119,7 @@ html {
   .layout-container {
     @apply mx-6;
   }
+
   .text-shadow-about-circles {
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
       1px 1px 0 #000;
@@ -140,7 +141,6 @@ html {
     .layout-container {
       @apply px-0;
     }
-
     .textbuttonField > p {
       @apply text-p;
     }
@@ -150,7 +150,6 @@ html {
     .layout-container {
       @apply container mx-auto px-6;
     }
-
     .circle-background {
       width: 120px;
       height: 120px;
@@ -308,12 +307,22 @@ li {
   box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
+.splash-bg {
+  background-size: 70%;
+}
+
 .card-shadow {
   box-shadow: 2px 4px 10px rgba(0, 0, 0, 0.1);
 }
 
 .info {
   display: flex;
+}
+
+@media (max-width: 640px) {
+  .splash-bg {
+    background-size: 100%;
+  }
 }
 
 @media (max-width: 990px) {


### PR DESCRIPTION
# Description

The purpose of this pr is to address some styling issue brought up by Nelia

1. The background image was stretched out on full screen, it should be the same as the one on mobile
![unnamed](https://user-images.githubusercontent.com/64853947/195403521-714ae8e6-91ac-400c-ac14-5e36af7b912b.jpg)
3. Footer should be aligned with the content
![unnamed](https://user-images.githubusercontent.com/64853947/195403560-1d375560-74dd-42f4-a7a1-e2b0492fcb73.png)

## Test Instructions

1. yarn dev
2. checkout the splash page image and the footer

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG


