### PR TITLE
Update homepage design and card component

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -16,55 +16,46 @@ export const Card = (props) => {
 
   return (
     <div
-      className={`${
-        props.blog
-          ? "card-shadow border border-custom-gray-border rounded-md px-4 py-2 pb-4 mb-8"
-          : props.isExperiment
-          ? "shadow-experiment-shadow -ml-8"
-          : ""
-      } ${"border-" + (tagColours[props.tag] || "gray-experiment")} min-w-full`}
+      className={`card-shadow border border-custom-gray-border rounded-md pb-4 ${
+        "border-" + (tagColours[props.tag] || "gray-experiment")
+      }`}
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
-      style={{
-        maxWidth: "557px",
-      }}
     >
-      {!props.blog ? (
-        <div className="mb-4">
-          <img src={props.imgSrc} alt={props.imgAlt} />
-        </div>
-      ) : undefined}
+      {props.showImage ? (
+        <img src={props.imgSrc} alt={props.imgAlt} className="mb-4 w-full" />
+      ) : (
+        ""
+      )}
       <h2>
-        {props.blog ? (
-          <div>
-            <Link href={props.href}>
-              <a className="text-canada-footer-font text-lg underline">
-                {props.title}
-              </a>
-            </Link>
-            <p className="text-base text-custom-gray-date">
-              {"Posted: " + props.datePosted.substring(0, 10)}
-            </p>
-          </div>
-        ) : props.isExperiment ? (
-          <Link href={props.href}>
-            <a
-              className="flex block text-p text-custom-blue-projects-link underline hover:opacity-70 px-4 items-center"
-              tabIndex="0"
-            >
-              {props.title}
-              {props.href.substring(0, 8) === "https://" ? (
+        <Link href={props.href}>
+          <a
+            className="flex block text-p mt-4 text-canada-footer-font text-lg text-custom-blue-projects-link underline hover:opacity-70 px-4 items-center"
+            tabIndex="0"
+          >
+            {props.title}
+            {props.showIcon ? (
+              props.href.substring(0, 8) === "https://" ? (
                 <div className="h-4 w-4 ml-1 mt-1 relative">
                   <img src={props.icon} alt={props.iconAlt} />
                 </div>
-              ) : undefined}
-            </a>
-          </Link>
+              ) : (
+                ""
+              )
+            ) : (
+              ""
+            )}
+          </a>
+        </Link>
+        {props.showDate ? (
+          <p className="ml-4 text-base text-custom-gray-date">
+            {"Posted: " + props.datePosted.substring(0, 10)}
+          </p>
         ) : (
-          props.title
+          ""
         )}
       </h2>
-      {props.isExperiment ? (
+      {props.showTag ? (
         <span
           className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ml-4 ${
             "border-" + (tagColours[props.tag] || "gray-experiment") + "-darker"
@@ -74,19 +65,13 @@ export const Card = (props) => {
         >
           {props.tagLabel}
         </span>
-      ) : undefined}
-      <p
-        className={`${
-          props.blog
-            ? "text-custom-gray-text"
-            : props.isExperiment
-            ? "ml-4 mb-4"
-            : ""
-        } mt-2 leading-30px text-lg`}
-      >
+      ) : (
+        ""
+      )}
+      <p className="text-custom-gray-text mx-4 leading-30px text-lg">
         {props.description}
       </p>
-      {!props.isExperiment && !props.blog ? (
+      {props.showButton ? (
         <ActionButton
           href={props.btnHref}
           text={props.btnText}
@@ -94,7 +79,9 @@ export const Card = (props) => {
           dataCy={props.btnId}
           className="flex mt-6 mb-2 rounded xxs:w-full xs:w-fit py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
         />
-      ) : undefined}
+      ) : (
+        ""
+      )}
     </div>
   );
 };
@@ -134,6 +121,31 @@ Card.propTypes = {
    * the test id for cypress test
    */
   dataCy: PropTypes.string,
+
+  /**
+   * Boolean value to show or hide image
+   */
+  showImage: PropTypes.bool,
+
+  /**
+   * Boolean value to show or hide button
+   */
+  showButton: PropTypes.bool,
+
+  /**
+   * Boolean value to show or hide date
+   */
+  showDate: PropTypes.bool,
+
+  /**
+   * Boolean value to show or hide icon beside title
+   */
+  showIcon: PropTypes.bool,
+
+  /**
+   * Boolean value to show or hide tag
+   */
+  showTag: PropTypes.bool,
 };
 
 export default Card;

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -77,7 +77,7 @@ export const Card = (props) => {
           text={props.btnText}
           id={props.btnId}
           dataCy={props.btnId}
-          className="flex mt-6 mb-2 rounded xxs:w-full xs:w-fit py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
+          className="flex mt-6 mb-2 ml-4 rounded xxs:w-full xs:w-fit py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
         />
       ) : (
         ""

--- a/components/molecules/Card.stories.js
+++ b/components/molecules/Card.stories.js
@@ -9,33 +9,50 @@ export default {
 const Template = (args) => <Card {...args} />;
 
 export const Primary = Template.bind({});
-export const Experiment = Template.bind({});
-export const Blog = Template.bind({});
+export const WithTag = Template.bind({});
+export const WithImage = Template.bind({});
+export const WithDate = Template.bind({});
+export const WithButton = Template.bind({});
 
 Primary.args = {
   title: "Title",
+  href: "/some/link",
   description: "Description",
   imgSrc: "/placeholderImg",
   imgAlt: "placeholderAlt",
 };
 
-Experiment.args = {
-  isExperiment: true,
+WithTag.args = {
+  showTag: true,
   title: "Title",
   tag: "experiment_tag",
   tagLabel: "Experiment tag",
   description: "Description",
   href: "/some/link",
+};
+
+WithImage.args = {
+  showImage: true,
+  title: "Title",
+  description: "Description",
+  href: "/somelink",
   imgSrc: "/placeholderImg",
   imgAlt: "placeholderAlt",
 };
 
-Blog.args = {
-  blog: true,
+WithDate.args = {
+  showDate: true,
   title: "Title",
   href: "/somelink",
   datePosted: "2022-01-01",
-  description: "Project description",
+  description: "Description",
+};
+
+WithButton.args = {
+  showButton: true,
+  title: "Title",
+  description: "Description",
+  href: "/somelink",
   btnHref: "/somelink",
-  btnText: "More about",
+  btnText: "Button text",
 };

--- a/components/molecules/Card.stories.js
+++ b/components/molecules/Card.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Card from "./Card";
+import Image from "../../public/placeholder.png";
 
 export default {
   title: "Components/Molecules/Card",
@@ -36,7 +37,7 @@ WithImage.args = {
   title: "Title",
   description: "Description",
   href: "/somelink",
-  imgSrc: "/placeholderImg",
+  imgSrc: Image,
   imgAlt: "placeholderAlt",
 };
 

--- a/components/molecules/Card.test.js
+++ b/components/molecules/Card.test.js
@@ -5,8 +5,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { Primary } from "./Card.stories";
-import { Experiment } from "./Card.stories";
-import { Blog } from "./Card.stories";
+import { WithTag } from "./Card.stories";
 
 expect.extend(toHaveNoViolations);
 
@@ -19,21 +18,13 @@ describe("Card tests", () => {
     expect(descriptionElement).toBeTruthy();
   });
 
-  it("renders Card in its Experiment state", () => {
-    render(<Experiment {...Experiment.args} />);
+  it("renders Card with tag", () => {
+    render(<WithTag {...WithTag.args} />);
     const titleElement = screen.getByText("Title");
     const tagElement = screen.getByText("Experiment tag");
     const descriptionElement = screen.getByText("Description");
     expect(titleElement).toBeTruthy();
     expect(tagElement).toBeTruthy();
-    expect(descriptionElement).toBeTruthy();
-  });
-
-  it("renders Card in its Blog state", () => {
-    render(<Blog {...Blog.args} />);
-    const titleElement = screen.getByText("Title");
-    const descriptionElement = screen.getByText("Project description");
-    expect(titleElement).toBeTruthy();
     expect(descriptionElement).toBeTruthy();
   });
 

--- a/pages/home.js
+++ b/pages/home.js
@@ -125,40 +125,47 @@ export default function Home(props) {
               ? pageData.scFragments[0].scContentEn.json[1].content[0].value
               : pageData.scFragments[0].scContentFr.json[1].content[0].value}
           </p>
-          <h2 className="mt-12 mb-6 text-h1l">
-            {props.locale === "en"
-              ? pageData.scFragments[0].scContentEn.json[2].content[0].value
-              : pageData.scFragments[0].scContentFr.json[2].content[0].value}
-          </h2>
-          <div className="mb-20 lg:flex">
-            <span className="w-full py-4">
-              <p className="mt-6">
+          <div className="flex pt-8">
+            <div>
+              <h2 className="mt-4 text-h1l">
                 {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[3].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[3].content[0]
-                      .value}{" "}
-              </p>
-              <br />
-              <span className="flex pt-12">
-                <ActionButton
-                  href={
-                    props.locale === "en"
-                      ? pageData.scFragments[2].scDestinationURLEn
-                      : pageData.scFragments[2].scDestinationURLFr
-                  }
-                  text={
-                    props.locale === "en"
-                      ? pageData.scFragments[2].scTitleEn
-                      : pageData.scFragments[2].scTitleFr
-                  }
-                  id={pageData.scFragments[2].scId}
-                  dataCy="AboutButton"
-                />
-              </span>
-            </span>
+                  ? pageData.scFragments[0].scContentEn.json[2].content[0].value
+                  : pageData.scFragments[0].scContentFr.json[2].content[0]
+                      .value}
+              </h2>
+              <div className="mb-20 lg:flex">
+                <span className="w-full">
+                  <p className="mt-4">
+                    {props.locale === "en"
+                      ? pageData.scFragments[0].scContentEn.json[3].content[0]
+                          .value
+                      : pageData.scFragments[0].scContentFr.json[3].content[0]
+                          .value}{" "}
+                  </p>
+                  <br />
+                  <span className="flex pt-2">
+                    <ActionButton
+                      className="bg-[#26374A]"
+                      href={
+                        props.locale === "en"
+                          ? pageData.scFragments[2].scDestinationURLEn
+                          : pageData.scFragments[2].scDestinationURLFr
+                      }
+                      text={
+                        props.locale === "en"
+                          ? pageData.scFragments[2].scTitleEn
+                          : pageData.scFragments[2].scTitleFr
+                      }
+                      id={pageData.scFragments[2].scId}
+                      dataCy="AboutButton"
+                    />
+                  </span>
+                </span>
+              </div>
+            </div>
             <span
-              className="relative hidden lg:flex w-full mt-4 lg:ml-8"
-              style={{ height: "316px", width: "452px", minWidth: "452px" }}
+              className="hidden xl:flex w-full mt-4 lg:ml-8"
+              style={{ height: "347px", width: "500px", minWidth: "500px" }}
               role="presentation"
             >
               <img
@@ -171,23 +178,13 @@ export default function Home(props) {
               />
             </span>
           </div>
-          <div className="xl:w-2/3"></div>
-          <div className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12">
+          <div className="grid lg:grid-cols-2 gap-x-8 lg:gap-y-12">
             <Card
+              showImage
               imgSrc={
                 props.locale === "en"
                   ? pageData.scFragments[3].scImageEn._publishUrl
                   : pageData.scFragments[3].scImageFr._publishUrl
-              }
-              imgHeight={
-                props.locale === "en"
-                  ? pageData.scFragments[3].scImageEn.height
-                  : pageData.scFragments[3].scImageFr.height
-              }
-              imgWidth={
-                props.locale === "en"
-                  ? pageData.scFragments[3].scImageEn.width
-                  : pageData.scFragments[3].scImageFr.width
               }
               imgAlt=""
               title={
@@ -195,61 +192,41 @@ export default function Home(props) {
                   ? pageData.scFragments[3].scTitleEn
                   : pageData.scFragments[3].scTitleFr
               }
+              href={
+                props.locale === "en"
+                  ? pageData.scFragments[3].scLabsButton[0].scDestinationURLEn
+                  : pageData.scFragments[3].scLabsButton[0].scDestinationURLFr
+              }
               description={
                 props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[0].content[0].value
                   : pageData.scFragments[3].scContentFr.json[0].content[0].value
               }
-              btnText={
-                props.locale === "en"
-                  ? pageData.scFragments[3].scLabsButton[0].scTitleEn
-                  : pageData.scFragments[3].scLabsButton[0].scTitleFr
-              }
-              btnHref={
-                props.locale === "en"
-                  ? pageData.scFragments[3].scLabsButton[0].scDestinationURLEn
-                  : pageData.scFragments[3].scLabsButton[0].scDestinationURLFr
-              }
               btnId={pageData.scFragments[3].scLabsButton[0].scId}
             />
             <Card
+              showImage
               imgSrc={
                 props.locale === "en"
                   ? pageData.scFragments[4].scImageEn._publishUrl
                   : pageData.scFragments[4].scImageFr._publishUrl
               }
               imgAlt=""
-              imgHeight={
-                props.locale === "en"
-                  ? pageData.scFragments[4].scImageEn.height
-                  : pageData.scFragments[4].scImageFr.height
-              }
-              imgWidth={
-                props.locale === "en"
-                  ? pageData.scFragments[4].scImageEn.width
-                  : pageData.scFragments[4].scImageFr.width
-              }
               title={
                 props.locale === "en"
                   ? pageData.scFragments[4].scTitleEn
                   : pageData.scFragments[4].scTitleFr
+              }
+              href={
+                props.locale === "en"
+                  ? pageData.scFragments[4].scLabsButton[0].scDestinationURLEn
+                  : pageData.scFragments[4].scLabsButton[0].scDestinationURLFr
               }
               description={
                 props.locale === "en"
                   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
                   : pageData.scFragments[4].scContentFr.json[0].content[0].value
               }
-              btnText={
-                props.locale === "en"
-                  ? pageData.scFragments[4].scLabsButton[0].scTitleEn
-                  : pageData.scFragments[4].scLabsButton[0].scTitleFr
-              }
-              btnHref={
-                props.locale === "en"
-                  ? pageData.scFragments[4].scLabsButton[0].scDestinationURLEn
-                  : pageData.scFragments[4].scLabsButton[0].scDestinationURLFr
-              }
-              btnId={pageData.scFragments[4].scLabsButton[0].scId}
             />
           </div>
         </section>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -250,12 +250,15 @@ export default function Projects(props) {
             dataCy={"filter-projects"}
           />
           <ul
-            className="grid gap-y-0 lg:grid-cols-2 lg:gap-x-11 lg:gap-y-4"
+            className="grid gap-x-4 lg:grid-cols-2 -ml-4"
             data-cy="projects-list"
           >
             {filteredExperiments.map((experiment) => (
               <li key={experiment.scId} className="flex items-stretch">
                 <Card
+                  showImage
+                  showTag
+                  showIcon
                   title={
                     props.locale === "en"
                       ? experiment.scTitleEn
@@ -291,13 +294,10 @@ export default function Projects(props) {
                   }
                   dataTestId={`${experiment.scId}`}
                   dataCy={`${experiment.scId}`}
-                  isExperiment
                   imgSrc="/placeholder.png"
                   //Eventually this alt text will change as we provide unique images for each project
                   imgAlt="placeholder"
                   //Manually entered width and height for now, will eventually take these values from AEM image data
-                  imgHeight={290}
-                  imgWidth={547}
                   icon={pageData.scFragments[3].scImageEn._publishUrl}
                   iconAlt={
                     props.locale === "en"

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -186,6 +186,7 @@ export default function Home(props) {
             </h2>
             {projectUpdates.map((data, index) => (
               <Card
+                showDate
                 key={index}
                 title={props.locale === "en" ? data.scTitleEn : data.scTitleFr}
                 datePosted={data.datePosted}


### PR DESCRIPTION
# Description

[DEV: Update homepage design and card component](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=81716)

Update request from Nelia:

- The image in the main content should align with the title
- Reduce spacing between paragraph, please check the updated design for homepage on [Figma](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?node-id=11385%3A29412)
- Remove the button in the cards on homepage, make title as links.

Since the Card component is also on Design System, and might be used in other projects, I made some adjustment on the component for reusability, please open story book to check the Card component in different states.

## Test Instructions

1. yarn dev
2. visit `/home` page and compare it with the updated design on Figma (link in description). 
3. open storybook in another terminal `yarn storybook`, check the card component in different state.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
