### PR TITLE
Created new model for Update/Blog pages and modified query for VA Update pages

### DIFF
--- a/graphql/queries/projectUpdatesQuery.graphql
+++ b/graphql/queries/projectUpdatesQuery.graphql
@@ -6,6 +6,8 @@ query getProjectUpdates {
       scTitleEn
       scTitleFr
       datePosted
+      scProject
+      scProjectPhase
       scDescriptionEn {
         json
       }

--- a/graphql/queries/virtualAssistantUpdatePagesQuery.graphql
+++ b/graphql/queries/virtualAssistantUpdatePagesQuery.graphql
@@ -1,5 +1,14 @@
 query getVirtualAssistantUpdatePages {
-    vaUpdatePageModelv1List {
+    scLabsBlogv1List(filter: {
+      scProject: {
+        _expressions: [
+          {
+            value: "va"
+            _operator: EQUALS
+          }
+        ]
+      }
+    }) {
     items {
       scId
       scPageNameEn
@@ -15,6 +24,8 @@ query getVirtualAssistantUpdatePages {
         json
       }
       scSubject
+      scProject
+      scProjectPhase
       scKeywordsEn
       scKeywordsFr
       scContentType

--- a/pages/projects/virtual-assistant/[id].js
+++ b/pages/projects/virtual-assistant/[id].js
@@ -190,7 +190,7 @@ export async function getStaticPaths() {
     "virtualAssistantUpdatePagesQuery"
   );
   // Get paths for dynamic routes from the page name data
-  const paths = getAllUpdateIds(data.vaUpdatePageModelv1List.items);
+  const paths = getAllUpdateIds(data.scLabsBlogv1List.items);
   return {
     paths,
     fallback: false,
@@ -206,7 +206,7 @@ export const getStaticProps = async ({ locale, params }) => {
   const { data } = await aemServiceInstance.getFragment(
     "virtualAssistantUpdatePagesQuery"
   );
-  const pages = data.vaUpdatePageModelv1List.items;
+  const pages = data.scLabsBlogv1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return page.scPageNameEn === params.id || page.scPageNameFr === params.id;


### PR DESCRIPTION
# Description

[Dynamic page model for blog](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=63969)

Created a new model for blog/update pages called "SCLabsBlog-v1" which includes two new single line string fields. Also created a new query for Virtual Assistant update pages which will only return pages related to VA from all the blog content fragments. 

The new string fields are as follows:

`scProject` is where you enter the string identifying the project with which this update page should be associated
`scProjectPhase` is where you enter the string identifying the phase that the project is in

I have also added these fields to the Project Update cards content fragment model and their query so that we can eventually filter them on the frontend similar to how we filter project cards based on project phase.

## Acceptance Criteria

The Virtual Assistant update page should work bilingually with the new model and query.

## Test Instructions

1. yarn dev
2. navigate to Virtual Assistant update page through the card
3. page should be seen working in both languages

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
