### PR TITLE
update button text size

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -145,7 +145,7 @@ export default function Home(props) {
                   <br />
                   <span className="flex pt-2">
                     <ActionButton
-                      className="bg-[#26374A]"
+                      className="bg-[#26374A] text-[20px]"
                       href={
                         props.locale === "en"
                           ? pageData.scFragments[2].scDestinationURLEn


### PR DESCRIPTION
# Description

Nelia's request to update the text size on the button on homepage. The text size should be 20px, to comply with the DS.
![homepage_font](https://user-images.githubusercontent.com/64853947/198087198-1ef8cb4c-b51b-4bb2-8006-4c398e372f8b.jpg)

## Test Instructions

1. yarn dev
2. visit /home
3. check the text size of the button
