### PR TITLE
update home and project page model

### DIFF
--- a/graphql/queries/homePageQuery.graphql
+++ b/graphql/queries/homePageQuery.graphql
@@ -1,5 +1,5 @@
 query getHomePage {
-  sCLabsPageByPath(
+  scLabsPagev1ByPath(
     _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/home-page"
   ) {
     item {

--- a/graphql/queries/projectQuery.graphql
+++ b/graphql/queries/projectQuery.graphql
@@ -1,5 +1,5 @@
 query getAllProjects {
-  sCLabsProjectList {
+  scLabsProjectv1List {
     items {
       _path
       scId
@@ -8,10 +8,10 @@ query getAllProjects {
       scDestinationURLEn
       scDestinationURLFr
       scContentEn {
-          json
+        json
       }
       scContentFr {
-          json
+        json
       }
       scLabProjectStatus
     }

--- a/graphql/queries/projectsPageQuery.graphql
+++ b/graphql/queries/projectsPageQuery.graphql
@@ -1,5 +1,5 @@
 query getProjectsPage {
-  sCLabsPageByPath(
+  scLabsPagev1ByPath(
     _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/projects-page"
   ) {
     item {
@@ -45,7 +45,7 @@ query getProjectsPage {
       scNoIndex
       scNoFollow
       scFragments {
-        ... on SCLabsContentModel {
+        ... on SCLabsContentv1Model {
           _path
           scId
           scContentEn {
@@ -55,7 +55,7 @@ query getProjectsPage {
             json
           }
         }
-        ... on SCLabsImageModel {
+        ... on SCLabsImagev1Model {
           scId
           scImageEn {
             ... on ImageRef {
@@ -99,10 +99,14 @@ query getProjectsPage {
           }
           scImageAltTextEn
           scImageAltTextFr
-          scImageCaptionEn
-          scImageCaptionFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
         }
-        ... on SCLabsButtonModel {
+        ... on SCLabsButtonv1Model {
           scId
           scTitleEn
           scTitleFr
@@ -110,7 +114,7 @@ query getProjectsPage {
           scDestinationURLFr
           scButtonType
         }
-        ... on SCLabsFeatureModel {
+        ... on SCLabsFeaturev1Model {
           scId
           scTitleEn
           scTitleFr
@@ -151,16 +155,16 @@ query getProjectsPage {
             scButtonType
           }
         }
-        ... on SCLabsAlertModel {
-            scId
-            scTitleEn
-            scTitleFr
-            scContentEn {
-                json
-            }
-            scContentFr {
-                json
-            }
+        ... on SCLabsAlertv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
         }
       }
     }

--- a/pages/home.js
+++ b/pages/home.js
@@ -247,7 +247,7 @@ export const getStaticProps = async ({ locale }) => {
     props: {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
-      pageData: data.sCLabsPageByPath,
+      pageData: data.scLabsPagev1ByPath,
       ...(await serverSideTranslations(locale, ["common"])),
     },
   };

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -336,7 +336,7 @@ export const getStaticProps = async ({ locale }) => {
     "projectsPageQuery"
   );
   const filters = Object.values(
-    experimentsData.sCLabsProjectList.items.reduce(
+    experimentsData.scLabsProjectv1List.items.reduce(
       (filters, { scLabProjectStatus }) => {
         if (!filters[scLabProjectStatus]) {
           filters[scLabProjectStatus] = {
@@ -369,8 +369,8 @@ export const getStaticProps = async ({ locale }) => {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
       ...(await serverSideTranslations(locale, ["common"])),
-      experimentData: experimentsData.sCLabsProjectList,
-      pageData: pageData.sCLabsPageByPath,
+      experimentData: experimentsData.scLabsProjectv1List,
+      pageData: pageData.scLabsPagev1ByPath,
       filters,
     },
   };


### PR DESCRIPTION
# Description

Migrated homepage and project page content to the v1 models, this pr update the graphql query to use the new models. 

## Acceptance Criteria

Home page and projects page (include project cards) are now using the v1 models

## Test Instructions

Make sure home page and projects page loads properly.