### PR TITLE
reverted project card query to sCLabbsProjectList query

### DIFF
--- a/graphql/queries/projectQuery.graphql
+++ b/graphql/queries/projectQuery.graphql
@@ -1,5 +1,5 @@
 query getAllProjects {
-  scLabsProjectv1List {
+  sCLabsProjectList {
     items {
       _path
       scId

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -336,7 +336,7 @@ export const getStaticProps = async ({ locale }) => {
     "projectsPageQuery"
   );
   const filters = Object.values(
-    experimentsData.scLabsProjectv1List.items.reduce(
+    experimentsData.sCLabsProjectList.items.reduce(
       (filters, { scLabProjectStatus }) => {
         if (!filters[scLabProjectStatus]) {
           filters[scLabProjectStatus] = {
@@ -369,7 +369,7 @@ export const getStaticProps = async ({ locale }) => {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
       ...(await serverSideTranslations(locale, ["common"])),
-      experimentData: experimentsData.scLabsProjectv1List,
+      experimentData: experimentsData.sCLabsProjectList,
       pageData: pageData.scLabsPagev1ByPath,
       filters,
     },


### PR DESCRIPTION
# Description

Previous commit changed the project card query to query the scLabsProject-v1 models. This caused the Virtual Assistant card to link to the separate VA page not hosted under SCLabs. This PR reverts the query to the previous model which links to the VA page under SCLabs.

## Acceptance Criteria

VA link on the projects page should link to the SCLabs VA page.