### PR TITLE
update va update page and breadcrumbs to use data from AEM

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -580,6 +580,21 @@ export const signupPage = {
         scDescriptionFr: {
           json: null,
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Sign up to be a voice in tomorrow's services",
+            scTitleFr:
+              "S’inscrire pour participer à l’élaboration des services de demain",
+            scPageNameEn: "/signup-info",
+            scPageNameFr: "/fr/inscription-info",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -843,6 +858,14 @@ export const signupInfoPageData = {
         scDescriptionFr: {
           json: null,
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -1983,6 +2006,20 @@ export const digitalCentrePageData = {
             },
           ],
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Explore our projects",
+            scTitleFr: "Explorer nos projets",
+            scPageNameEn: "/en/projects",
+            scPageNameFr: "/fr/projets",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -4080,6 +4117,20 @@ export const havingAChildPageData = {
             },
           ],
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Explore our projects",
+            scTitleFr: "Explorer nos projets",
+            scPageNameEn: "/en/projects",
+            scPageNameFr: "/fr/projets",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -4964,6 +5015,20 @@ export const virtualAssistantPageData = {
             },
           ],
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Explore our projects",
+            scTitleFr: "Explorer nos projets",
+            scPageNameEn: "/en/projects",
+            scPageNameFr: "/fr/projets",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -5855,6 +5920,21 @@ export const privacyPageData = {
         scDescriptionFr: {
           json: null,
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Sign up to be a voice in tomorrow's services",
+            scTitleFr:
+              "S’inscrire pour participer à l’élaboration des services de demain",
+            scPageNameEn: "/signup-info",
+            scPageNameFr: "/fr/inscription-info",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,
@@ -6841,6 +6921,26 @@ export const tryVirtualAssistantPageData = {
         scDescriptionFr: {
           json: null,
         },
+        scBreadcrumbParentPages: [
+          {
+            scTitleEn: "Service Canada Labs",
+            scTitleFr: "Laboratoires de Service Canada",
+            scPageNameEn: "/en/home",
+            scPageNameFr: "/fr/accueil",
+          },
+          {
+            scTitleEn: "Explore our projects",
+            scTitleFr: "Explorer nos projets",
+            scPageNameEn: "/en/projects",
+            scPageNameFr: "/fr/projets",
+          },
+          {
+            scTitleEn: "Virtual Assistant",
+            scTitleFr: "Assistant virtuel",
+            scPageNameEn: "/en/projects/virtual-assistant",
+            scPageNameFr: "/fr/projets/assistant-virtuel",
+          },
+        ],
         scSubject: null,
         scKeywordsEn: null,
         scKeywordsFr: null,

--- a/graphql/queries/digitalCentreQuery.graphql
+++ b/graphql/queries/digitalCentreQuery.graphql
@@ -16,6 +16,14 @@ query getDigitalCentrePage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/havingAChildQuery.graphql
+++ b/graphql/queries/havingAChildQuery.graphql
@@ -16,6 +16,14 @@ query getHavingAChildPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/homePageQuery.graphql
+++ b/graphql/queries/homePageQuery.graphql
@@ -16,6 +16,14 @@ query getHomePage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/privacyPageQuery.graphql
+++ b/graphql/queries/privacyPageQuery.graphql
@@ -16,6 +16,14 @@ query getPrivacyPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/projectUpdatesQuery.graphql
+++ b/graphql/queries/projectUpdatesQuery.graphql
@@ -16,6 +16,12 @@ query getProjectUpdates {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/projectsPageQuery.graphql
+++ b/graphql/queries/projectsPageQuery.graphql
@@ -16,6 +16,14 @@ query getProjectsPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/signupInfoQuery.graphql
+++ b/graphql/queries/signupInfoQuery.graphql
@@ -16,6 +16,14 @@ query getsignupInfoPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/signupQuery.graphql
+++ b/graphql/queries/signupQuery.graphql
@@ -16,6 +16,14 @@ query getSignupPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/signupReviewQuery.graphql
+++ b/graphql/queries/signupReviewQuery.graphql
@@ -16,6 +16,14 @@ query getsignupReviewPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/tryVirtualAssistantQuery.graphql
+++ b/graphql/queries/tryVirtualAssistantQuery.graphql
@@ -16,6 +16,14 @@ query getVATryItOutPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/virtualAssistantQuery.graphql
+++ b/graphql/queries/virtualAssistantQuery.graphql
@@ -16,6 +16,14 @@ query getVirtualAssistantPage {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scKeywordsEn
       scKeywordsFr

--- a/graphql/queries/virtualAssistantUpdatePagesQuery.graphql
+++ b/graphql/queries/virtualAssistantUpdatePagesQuery.graphql
@@ -1,14 +1,9 @@
 query getVirtualAssistantUpdatePages {
-    scLabsBlogv1List(filter: {
-      scProject: {
-        _expressions: [
-          {
-            value: "va"
-            _operator: EQUALS
-          }
-        ]
-      }
-    }) {
+  scLabsPagev1List(
+    filter: {
+      scProject: { _expressions: [{ value: "va", _operator: EQUALS }] }
+    }
+  ) {
     items {
       scId
       scPageNameEn
@@ -23,9 +18,16 @@ query getVirtualAssistantUpdatePages {
       scDescriptionFr {
         json
       }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
       scSubject
       scProject
-      scProjectPhase
       scKeywordsEn
       scKeywordsFr
       scContentType

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -56,7 +56,16 @@ export default function Projects(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/projects/digital-centre.js
+++ b/pages/projects/digital-centre.js
@@ -49,8 +49,26 @@ export default function DigitalCenter(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("menuLink1"), link: t("breadCrumbsHref2") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
         ]}
         projectName={t("dc:OverviewTitle")}
       >

--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -25,8 +25,26 @@ export default function LifeJourneys(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("menuLink1"), link: t("breadCrumbsHref2") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/projects/virtual-assistant/[id].js
+++ b/pages/projects/virtual-assistant/[id].js
@@ -32,9 +32,36 @@ export default function VAUpdatePage(props) {
             : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("menuLink1"), link: t("breadCrumbsHref2") },
-          { text: t("menuLink3"), link: t("breadCrumbsHref5") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scTitleEn
+                : pageData.scBreadcrumbParentPages[2].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scPageNameEn
+                : pageData.scBreadcrumbParentPages[2].scPageNameFr,
+          },
         ]}
       >
         <Head>
@@ -190,7 +217,7 @@ export async function getStaticPaths() {
     "virtualAssistantUpdatePagesQuery"
   );
   // Get paths for dynamic routes from the page name data
-  const paths = getAllUpdateIds(data.scLabsBlogv1List.items);
+  const paths = getAllUpdateIds(data.scLabsPagev1List.items);
   return {
     paths,
     fallback: false,
@@ -206,7 +233,7 @@ export const getStaticProps = async ({ locale, params }) => {
   const { data } = await aemServiceInstance.getFragment(
     "virtualAssistantUpdatePagesQuery"
   );
-  const pages = data.scLabsBlogv1List.items;
+  const pages = data.scLabsPagev1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return page.scPageNameEn === params.id || page.scPageNameFr === params.id;

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -39,8 +39,26 @@ export default function Home(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("menuLink1"), link: t("breadCrumbsHref2") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
         ]}
       >
         <Head>
@@ -243,8 +261,8 @@ export default function Home(props) {
               // managers won't need to concern themselves with multi-part URLs
               href={
                 props.locale === "en"
-                  ? projectUpdates.scPageNameEn
-                  : projectUpdates.scPageNameFr
+                  ? `/projects/virtual-assistant/${projectUpdates.scPageNameEn}`
+                  : `/projets/assistant-virtuel/${projectUpdates.scPageNameFr}`
               }
               blog
             />

--- a/pages/projects/virtual-assistant/try-it-out.js
+++ b/pages/projects/virtual-assistant/try-it-out.js
@@ -28,9 +28,36 @@ export default function Home(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("menuLink1"), link: t("breadCrumbsHref2") },
-          { text: t("menuLink3"), link: t("breadCrumbsHref5") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scTitleEn
+                : pageData.scBreadcrumbParentPages[2].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scPageNameEn
+                : pageData.scBreadcrumbParentPages[2].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/signup-info.js
+++ b/pages/signup-info.js
@@ -27,7 +27,16 @@ export default function SignupInfo(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/signup-review.js
+++ b/pages/signup-review.js
@@ -210,9 +210,36 @@ export default function SignupReview(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("signupInfoTitle"), link: t("breadCrumbsHref4") },
-          { text: t("signupLink"), link: t("breadCrumbsHref3") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scTitleEn
+                : pageData.scBreadcrumbParentPages[2].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[2].scPageNameEn
+                : pageData.scBreadcrumbParentPages[2].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -441,8 +441,26 @@ export default function Signup(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("signupInfoTitle"), link: t("breadCrumbsHref4") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
         ]}
       >
         <Head>

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -34,8 +34,26 @@ export default function Privacy(props) {
         locale={props.locale}
         langUrl={t("privacyPath")}
         breadcrumbItems={[
-          { text: t("siteTitle"), link: t("breadCrumbsHref1") },
-          { text: t("signupHomeButton"), link: t("breadCrumbsHref3") },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scTitleEn
+                : pageData.scBreadcrumbParentPages[1].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[1].scPageNameEn
+                : pageData.scBreadcrumbParentPages[1].scPageNameFr,
+          },
         ]}
       >
         <Head>


### PR DESCRIPTION
# Description

Migrated virtual assistant post page to the new model. The page was using `Blog-v1` model, switching to the `Page-v1` model.

I also updated the breadcrumb items for each page to use data from AEM

## Test Instructions

1. Check the virtual assistant post page projects/virtual-assistant/what-we-learned, make sure the content are correct, and the links work properly
2. Check the breadcrumb links for each pages
