### PR TITLE
handle period at end of Alert/disclaimer link as separate data node

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -246,6 +246,7 @@ export default function Home(props) {
                         .value
                     }
                   </a>
+                  {pageData.scFragments[2].scContentEn.json[0].content[2].value}
                 </>
               ) : (
                 <>
@@ -262,6 +263,7 @@ export default function Home(props) {
                         .value
                     }
                   </a>
+                  {pageData.scFragments[2].scContentEn.json[0].content[2].value}
                 </>
               )
             }


### PR DESCRIPTION
# Description

Adds line to handle the period at the end of the homepage Alert component so that it is not a part of the link.

## Acceptance Criteria

Period should be separate to the link in the Alert/disclaimer on the home page. 

## Test Instructions

1. Got o homepage
2. Scroll down to the Alert
3. See that the period is not a character in the link
