### PR TITLE
Get project stage from page properties and compose project stage tooltip from tooltip content fragment

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -7963,6 +7963,7 @@ export const oasBenefitsEstimatorData = {
         scTitleFr: "Estimateur des prestations de la Sécurité de la vieillesse",
         scShortTitleEn: null,
         scShortTitleFr: null,
+        scLabProjectStage: ["gc:custom/decd-endc/project-stage/alpha"],
         scDescriptionEn: {
           json: [
             {
@@ -8004,7 +8005,7 @@ export const oasBenefitsEstimatorData = {
         scKeywordsFr: null,
         scContentType: null,
         scOwner: null,
-        scDateModifiedOverwrite: "2023-01-19",
+        scDateModifiedOverwrite: "2023-01-17",
         scAudience: null,
         scRegion: null,
         scSocialMediaImageEn: {
@@ -8062,7 +8063,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Beta",
+                      value: "Alpha",
                     },
                   ],
                 },
@@ -8302,7 +8303,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Bêta",
+                      value: "Alpha",
                     },
                   ],
                 },
@@ -8540,8 +8541,10 @@ export const oasBenefitsEstimatorData = {
           },
           {
             _path:
-              "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/beta-definition",
-            scId: "BETA-DEFINITION",
+              "/content/dam/decd-endc/content-fragments/sclabs/components/tooltips/information-alpha",
+            scId: "INFORMATION-ALPHA-SCLABS",
+            scTitleEn: "Information",
+            scTitleFr: "Information",
             scContentEn: {
               json: [
                 {
@@ -8549,7 +8552,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Beta: ",
+                      value: "Alpha:",
                       format: {
                         variants: ["strong"],
                       },
@@ -8557,7 +8560,7 @@ export const oasBenefitsEstimatorData = {
                     {
                       nodeType: "text",
                       value:
-                        "Building an almost fully functional version of a tool or service, testing it in public and preparing to launch it.",
+                        ' Building a "proof of concept" tool or service to meet user needs and testing it with users.',
                     },
                   ],
                 },
@@ -8570,7 +8573,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Bêta :",
+                      value: "Alpha : ",
                       format: {
                         variants: ["strong"],
                       },
@@ -8578,7 +8581,54 @@ export const oasBenefitsEstimatorData = {
                     {
                       nodeType: "text",
                       value:
-                        " Construire une version presque entièrement fonctionnelle d'un outil ou d'un service, la tester auprès du public et préparer son lancement.",
+                        "Construction d'un outil ou d'un service comme « preuve de concept » répondant aux besoins des utilisateurs et testé par ces derniers.",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/alpha-definition",
+            scId: "ALPHA-DEFINITION",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Alpha:",
+                      format: {
+                        variants: ["strong"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        ' Building a "proof of concept" tool or service to meet user needs and testing it with users.',
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Alpha :",
+                      format: {
+                        variants: ["strong"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " Construction d'un outil ou d'un service comme « preuve de concept » répondant aux besoins des utilisateurs et testé par ces derniers.",
                     },
                   ],
                 },

--- a/graphql/queries/oasBenefitsEstimatorQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorQuery.graphql
@@ -10,6 +10,7 @@ query getOASBenefitsEstimatorPage {
       scTitleFr
       scShortTitleEn
       scShortTitleFr
+      scLabProjectStage
       scDescriptionEn {
         json
       }
@@ -176,6 +177,17 @@ query getOASBenefitsEstimatorPage {
             scDestinationURLEn
             scDestinationURLFr
             scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
           }
         }
       }

--- a/graphql/queries/oasBenefitsEstimatorQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorQuery.graphql
@@ -180,6 +180,7 @@ query getOASBenefitsEstimatorPage {
           }
         }
         ... on Tooltipv1Model {
+          _path
           scId
           scTitleEn
           scTitleFr

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -20,6 +20,16 @@ export default function oasBenefitsEstimator(props) {
         item.scId === "SUMMARY"
     )
   );
+  const stageDictionary = {
+    en: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Beta",
+    },
+    fr: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Bêta",
+    },
+  };
 
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
@@ -206,13 +216,15 @@ export default function oasBenefitsEstimator(props) {
                     : pageData.scFragments[2].scContentFr.json[0].content[1]
                         .value
                 }
-                information="information"
+                information={
+                  props.locale === "en"
+                    ? pageData.scFragments[2].scTitleEn
+                    : pageData.scFragments[2].scTitleFr
+                }
                 stage={
                   props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[3].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[3].content[0]
-                        .value
+                    ? stageDictionary.en[pageData.scLabProjectStage]
+                    : stageDictionary.fr[pageData.scLabProjectStage]
                 }
                 summary={
                   props.locale === "en"
@@ -382,19 +394,19 @@ export default function oasBenefitsEstimator(props) {
           }
           description={
             props.locale === "en"
-              ? pageData.scFragments[5].scContentEn.json[0].content[0].value
-              : pageData.scFragments[5].scContentFr.json[0].content[0].value
+              ? pageData.scFragments[6].scContentEn.json[0].content[0].value
+              : pageData.scFragments[6].scContentFr.json[0].content[0].value
           }
           lang={props.locale}
           href={
             props.locale === "en"
-              ? pageData.scFragments[5].scLabsButton[0].scDestinationURLEn
-              : pageData.scFragments[5].scLabsButton[0].scDestinationURLFr
+              ? pageData.scFragments[6].scLabsButton[0].scDestinationURLEn
+              : pageData.scFragments[6].scLabsButton[0].scDestinationURLFr
           }
           hrefText={
             props.locale === "en"
-              ? pageData.scFragments[5].scLabsButton[0].scTitleEn
-              : pageData.scFragments[5].scLabsButton[0].scTitleFr
+              ? pageData.scFragments[6].scLabsButton[0].scTitleEn
+              : pageData.scFragments[6].scLabsButton[0].scTitleFr
           }
         />
       </Layout>

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -287,13 +287,13 @@ export default function oasBenefitsEstimator(props) {
                 className=""
                 href={
                   props.locale === "en"
-                    ? pageData.scFragments[3].scDestinationURLEn
-                    : pageData.scFragments[3].scDestinationURLFr
+                    ? pageData.scFragments[4].scDestinationURLEn
+                    : pageData.scFragments[4].scDestinationURLFr
                 }
                 text={
                   props.locale === "en"
-                    ? pageData.scFragments[3].scTitleEn
-                    : pageData.scFragments[3].scTitleFr
+                    ? pageData.scFragments[4].scTitleEn
+                    : pageData.scFragments[4].scTitleFr
                 }
                 ariaExpanded={props.ariaExpanded}
               />
@@ -303,13 +303,13 @@ export default function oasBenefitsEstimator(props) {
                 className=""
                 href={
                   props.locale === "en"
-                    ? pageData.scFragments[4].scDestinationURLEn
-                    : pageData.scFragments[4].scDestinationURLFr
+                    ? pageData.scFragments[5].scDestinationURLEn
+                    : pageData.scFragments[5].scDestinationURLFr
                 }
                 text={
                   props.locale === "en"
-                    ? pageData.scFragments[4].scTitleEn
-                    : pageData.scFragments[4].scTitleFr
+                    ? pageData.scFragments[5].scTitleEn
+                    : pageData.scFragments[5].scTitleFr
                 }
                 ariaExpanded={props.ariaExpanded}
               />


### PR DESCRIPTION
# Description

Previously, the "Information" label content was hardcoded into the component. Now it is fetched from the scTitle in the tooltip fragment attached to the OAS page model so it can be modified from AEM.

Also, project stage on the OAS page is pulled from the scLabProjectStage property found in the page model's properties. The tooltip content is pulled from the tooltip content fragment associated with the OAS page like the "Information" label content.

![Screenshot 2023-02-16 at 10 19 52 AM](https://user-images.githubusercontent.com/31868510/219453524-e08bb42e-b3ae-4684-bac3-488064edea9b.png)

## Acceptance Criteria

Project stage should show Alpha, and the tooltip should correspond in both languages.

## Test Instructions

1. Go to OAS overview page
2. Ensure label says Alpha and the tooltip works and corresponds
