### PR TITLE
update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,10 +1516,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lottiefiles/react-lottie-player@^3.4.7":
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/@lottiefiles/react-lottie-player/-/react-lottie-player-3.5.0.tgz"
-  integrity sha512-RSlqcq9d204sqmG5ithFYQwxovLP96uj8yY+f2U8WPtdmv4zMvx1C4V4wv5nlcr2drSxvoyykM50YrVDpXjKwQ==
+"@lottiefiles/react-lottie-player@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/@lottiefiles/react-lottie-player/-/react-lottie-player-3.5.2.tgz#4ed1bb5b59bc200201d51dba7a75f597ce48f268"
+  integrity sha512-vrvRgqXimIpM5GUzBP6aksZjCdLUGxTL3FZ+2NJzLmKkPL3xDEX7oCftqPSerFz1AXVwIur3FaZbWL+XyagXWQ==
   dependencies:
     lottie-web "^5.10.0"
 


### PR DESCRIPTION
# Description

Snyk package updates seem to be breaking the builds in the pipeline due to yarn.lock not being updated before it runs with --frozen-lockfile in the pipeline. Right now this means having to bring in the branch with the snyk update to your local machine, running `yarn install` to update the yarn.lock and then pushing out that change. We should explore our options to automate this better.
