### PR TITLE
Enable HTML entities in tooltip content to manage breaking spaces

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -7963,6 +7963,7 @@ export const oasBenefitsEstimatorData = {
         scTitleFr: "Estimateur des prestations de la Sécurité de la vieillesse",
         scShortTitleEn: null,
         scShortTitleFr: null,
+        scLabProjectStage: ["gc:custom/decd-endc/project-stage/alpha"],
         scDescriptionEn: {
           json: [
             {
@@ -8004,7 +8005,7 @@ export const oasBenefitsEstimatorData = {
         scKeywordsFr: null,
         scContentType: null,
         scOwner: null,
-        scDateModifiedOverwrite: "2023-01-19",
+        scDateModifiedOverwrite: "2023-01-17",
         scAudience: null,
         scRegion: null,
         scSocialMediaImageEn: {
@@ -8062,7 +8063,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Beta",
+                      value: "Alpha",
                     },
                   ],
                 },
@@ -8302,7 +8303,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Bêta",
+                      value: "Alpha",
                     },
                   ],
                 },
@@ -8540,8 +8541,10 @@ export const oasBenefitsEstimatorData = {
           },
           {
             _path:
-              "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/beta-definition",
-            scId: "BETA-DEFINITION",
+              "/content/dam/decd-endc/content-fragments/sclabs/components/tooltips/information-alpha",
+            scId: "INFORMATION-ALPHA-SCLABS",
+            scTitleEn: "Information",
+            scTitleFr: "Information",
             scContentEn: {
               json: [
                 {
@@ -8549,7 +8552,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Beta: ",
+                      value: "Alpha:",
                       format: {
                         variants: ["strong"],
                       },
@@ -8557,7 +8560,7 @@ export const oasBenefitsEstimatorData = {
                     {
                       nodeType: "text",
                       value:
-                        "Building an almost fully functional version of a tool or service, testing it in public and preparing to launch it.",
+                        ' Building a "proof of concept" tool or service to meet user needs and testing it with users.',
                     },
                   ],
                 },
@@ -8570,7 +8573,7 @@ export const oasBenefitsEstimatorData = {
                   content: [
                     {
                       nodeType: "text",
-                      value: "Bêta :",
+                      value: "Alpha : ",
                       format: {
                         variants: ["strong"],
                       },
@@ -8578,7 +8581,54 @@ export const oasBenefitsEstimatorData = {
                     {
                       nodeType: "text",
                       value:
-                        " Construire une version presque entièrement fonctionnelle d'un outil ou d'un service, la tester auprès du public et préparer son lancement.",
+                        "Construction d'un outil ou d'un service comme « preuve de concept » répondant aux besoins des utilisateurs et testé par ces derniers.",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/alpha-definition",
+            scId: "ALPHA-DEFINITION",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Alpha:",
+                      format: {
+                        variants: ["strong"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        ' Building a "proof of concept" tool or service to meet user needs and testing it with users.',
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Alpha :",
+                      format: {
+                        variants: ["strong"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " Construction d'un outil ou d'un service comme « preuve de concept » répondant aux besoins des utilisateurs et testé par ces derniers.",
                     },
                   ],
                 },

--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -61,10 +61,15 @@ export function ProjectInfo(props) {
                   className="absolute border rounded-md px-4 py-2 my-2"
                 >
                   {
-                    <p tabIndex={0}>
-                      <strong>{props.term}</strong>
-                      {props.definition}
-                    </p>
+                    <>
+                      <p tabIndex={0} className="inline">
+                        <strong>{props.term}</strong>
+                      </p>
+                      <p
+                        className="inline"
+                        dangerouslySetInnerHTML={{ __html: props.definition }}
+                      ></p>
+                    </>
                   }
                 </div>
               </div>

--- a/graphql/queries/oasBenefitsEstimatorQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorQuery.graphql
@@ -10,6 +10,7 @@ query getOASBenefitsEstimatorPage {
       scTitleFr
       scShortTitleEn
       scShortTitleFr
+      scLabProjectStage
       scDescriptionEn {
         json
       }
@@ -176,6 +177,18 @@ query getOASBenefitsEstimatorPage {
             scDestinationURLEn
             scDestinationURLFr
             scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
           }
         }
       }

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -20,6 +20,16 @@ export default function oasBenefitsEstimator(props) {
         item.scId === "SUMMARY"
     )
   );
+  const stageDictionary = {
+    en: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Beta",
+    },
+    fr: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Bêta",
+    },
+  };
 
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
@@ -206,13 +216,15 @@ export default function oasBenefitsEstimator(props) {
                     : pageData.scFragments[2].scContentFr.json[0].content[1]
                         .value
                 }
-                information="information"
+                information={
+                  props.locale === "en"
+                    ? pageData.scFragments[2].scTitleEn
+                    : pageData.scFragments[2].scTitleFr
+                }
                 stage={
                   props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[3].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[3].content[0]
-                        .value
+                    ? stageDictionary.en[pageData.scLabProjectStage]
+                    : stageDictionary.fr[pageData.scLabProjectStage]
                 }
                 summary={
                   props.locale === "en"
@@ -275,13 +287,13 @@ export default function oasBenefitsEstimator(props) {
                 className=""
                 href={
                   props.locale === "en"
-                    ? pageData.scFragments[3].scDestinationURLEn
-                    : pageData.scFragments[3].scDestinationURLFr
+                    ? pageData.scFragments[4].scDestinationURLEn
+                    : pageData.scFragments[4].scDestinationURLFr
                 }
                 text={
                   props.locale === "en"
-                    ? pageData.scFragments[3].scTitleEn
-                    : pageData.scFragments[3].scTitleFr
+                    ? pageData.scFragments[4].scTitleEn
+                    : pageData.scFragments[4].scTitleFr
                 }
                 ariaExpanded={props.ariaExpanded}
               />
@@ -291,13 +303,13 @@ export default function oasBenefitsEstimator(props) {
                 className=""
                 href={
                   props.locale === "en"
-                    ? pageData.scFragments[4].scDestinationURLEn
-                    : pageData.scFragments[4].scDestinationURLFr
+                    ? pageData.scFragments[5].scDestinationURLEn
+                    : pageData.scFragments[5].scDestinationURLFr
                 }
                 text={
                   props.locale === "en"
-                    ? pageData.scFragments[4].scTitleEn
-                    : pageData.scFragments[4].scTitleFr
+                    ? pageData.scFragments[5].scTitleEn
+                    : pageData.scFragments[5].scTitleFr
                 }
                 ariaExpanded={props.ariaExpanded}
               />
@@ -382,19 +394,19 @@ export default function oasBenefitsEstimator(props) {
           }
           description={
             props.locale === "en"
-              ? pageData.scFragments[5].scContentEn.json[0].content[0].value
-              : pageData.scFragments[5].scContentFr.json[0].content[0].value
+              ? pageData.scFragments[6].scContentEn.json[0].content[0].value
+              : pageData.scFragments[6].scContentFr.json[0].content[0].value
           }
           lang={props.locale}
           href={
             props.locale === "en"
-              ? pageData.scFragments[5].scLabsButton[0].scDestinationURLEn
-              : pageData.scFragments[5].scLabsButton[0].scDestinationURLFr
+              ? pageData.scFragments[6].scLabsButton[0].scDestinationURLEn
+              : pageData.scFragments[6].scLabsButton[0].scDestinationURLFr
           }
           hrefText={
             props.locale === "en"
-              ? pageData.scFragments[5].scLabsButton[0].scTitleEn
-              : pageData.scFragments[5].scLabsButton[0].scTitleFr
+              ? pageData.scFragments[6].scLabsButton[0].scTitleEn
+              : pageData.scFragments[6].scLabsButton[0].scTitleFr
           }
         />
       </Layout>


### PR DESCRIPTION
# Description

This PR allows AEM content editors to use HTML entities in their content to manage spaces etc. in the tooltip section of the ProjectInfo component.

## Acceptance Criteria

AEM editors should be able to leverage non-breaking spaces in their content.

## Test Instructions

1. Navigate to OAS overview page
2. Ensure you have French toggled
3. Click tooltip button "Information"
4. See that the quote "<< preuve de concept >>" does not break on spaces immediately between the quotation marks and their proceeding/preceding characters.
