### PR TITLE
update footer privacy link

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -47,7 +47,7 @@
   "footerTermsAndCondition": "Terms and conditions",
   "footerTermsAndConditionURL": "https://www.canada.ca/en/transparency/terms.html",
   "footerPrivacy": "Privacy",
-  "footerPrivacyURL": "https://www.canada.ca/en/transparency/privacy.html",
+  "footerPrivacyURL": "/en/signup/privacy",
   "reportAProblemTitle": "Report a problem or mistake on this page",
   "reportAProblemCheckAllThatApply": "Check all the issues that apply",
   "reportAProblemIncorrectInformation": "Incorrect Information",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -74,7 +74,7 @@
   "footerTermsAndCondition": "Avis",
   "footerTermsAndConditionURL": "https://www.canada.ca/fr/transparence/avis.html",
   "footerPrivacy": "Confidentialité",
-  "footerPrivacyURL": "https://www.canada.ca/fr/transparence/confidentialite.html",
+  "footerPrivacyURL": "/fr/inscription/protection-renseignements-personnels",
   "menuTitle": "MENU",
   "menuLink1": "Explorer nos projets",
   "menuLink2": "À propos des laboratoires",


### PR DESCRIPTION
# Description

[DEV: Footer link: Privacy Policy links to Canada.ca instead of SC Labs; let's change it](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=69152)

Update the privacy link in footer to link to SCLabs privacy page.

## Test Instructions

Click on the footer privacy link. The link should redirect to SCLabs privacy page. 

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
