### PR TITLE
made card clickable, updated <a> tag formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Project cards get their images and content from v1 Page fragments associated with a given project
 - Home page updated to new design for EE launch
 - Changed button hover-state colour from #1F809A to #1C578A to align with Design System
+- Changed projects card to clickable components
 
 ## Fixed
 

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -16,28 +16,28 @@ export const Card = (props) => {
   };
 
   return (
-    <div
-      className={`card-shadow border border-custom-gray-border rounded-md pb-4 ${
-        "border-" + (tagColours[props.tag] || "gray-experiment")
-      }`}
-      data-testid={props.dataTestId}
-      data-cy={props.dataCy}
-    >
-      {props.showImage ? (
-        <div className="h-80 flex justify-center">
-          <img
-            src={props.imgSrc}
-            alt={props.imgAlt}
-            className="xxl:mt-4 mb-4 object-cover rounded-md"
-          />
-        </div>
-      ) : (
-        ""
-      )}
-      <h2>
-        <Link href={props.href}>
+    <Link href={props.href}>
+      <div
+        className={`group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
+          "border-" + (tagColours[props.tag] || "gray-experiment")
+        }`}
+        data-testid={props.dataTestId}
+        data-cy={props.dataCy}
+      >
+        {props.showImage ? (
+          <div className="h-80 flex justify-center">
+            <img
+              src={props.imgSrc}
+              alt={props.imgAlt}
+              className="xxl:mt-4 mb-4 object-cover rounded-md"
+            />
+          </div>
+        ) : (
+          ""
+        )}
+        <h2>
           <a
-            className="flex block text-p mt-4 text-canada-footer-font text-lg text-custom-blue-projects-link underline hover:opacity-70 px-4 items-center"
+            className="block mt-4 text-lg text-custom-blue-projects-link underline px-4 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
             tabIndex="0"
           >
             {props.title}
@@ -53,43 +53,45 @@ export const Card = (props) => {
               ""
             )}
           </a>
-        </Link>
-        {props.showDate ? (
-          <p className="ml-4 text-base text-custom-gray-date">
-            {"Posted: " + props.datePosted.substring(0, 10)}
-          </p>
+          {props.showDate ? (
+            <p className="ml-4 text-base text-custom-gray-date">
+              {"Posted: " + props.datePosted.substring(0, 10)}
+            </p>
+          ) : (
+            ""
+          )}
+        </h2>
+        {props.showTag ? (
+          <span
+            className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ml-4 ${
+              "border-" +
+              (tagColours[props.tag] || "gray-experiment") +
+              "-darker"
+            } ${
+              "bg-" + (tagColours[props.tag] || "gray-experiment") + "-lighter"
+            }`}
+          >
+            {props.tagLabel}
+          </span>
         ) : (
           ""
         )}
-      </h2>
-      {props.showTag ? (
-        <span
-          className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ml-4 ${
-            "border-" + (tagColours[props.tag] || "gray-experiment") + "-darker"
-          } ${
-            "bg-" + (tagColours[props.tag] || "gray-experiment") + "-lighter"
-          }`}
-        >
-          {props.tagLabel}
-        </span>
-      ) : (
-        ""
-      )}
-      <p className="text-custom-gray-text mx-4 leading-30px text-lg">
-        {props.description}
-      </p>
-      {props.showButton ? (
-        <ActionButton
-          href={props.btnHref}
-          text={props.btnText}
-          id={props.btnId}
-          dataCy={props.btnId}
-          className="flex mt-6 mb-2 ml-4 rounded xxs:w-full xs:w-fit py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
-        />
-      ) : (
-        ""
-      )}
-    </div>
+        <p className="text-custom-gray-text mx-4 leading-30px text-lg">
+          {props.description}
+        </p>
+        {props.showButton ? (
+          <ActionButton
+            href={props.btnHref}
+            text={props.btnText}
+            id={props.btnId}
+            dataCy={props.btnId}
+            className="flex mt-6 mb-2 ml-4 rounded xxs:w-full xs:w-fit py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
+          />
+        ) : (
+          ""
+        )}
+      </div>
+    </Link>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,7 @@ module.exports = {
           hover: "#083DCA",
           "experiment-blue": "#004986",
           "projects-link": "#2B4380",
+          "projects-link-hover": "#0535d2",
         },
         "custom-green": {
           lighter: "#D8EECA",


### PR DESCRIPTION
# Description

[106494 Make project cards clickable across the whole component](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)

Makes the project cards on the home page clickable (vs just a hyperlink in the title). Removes hyperlink formatting and replaces with transparency on hover.

## Acceptance Criteria

Card style should match the cards at the bottom of canada.ca

## Test Instructions

1. navigate to /home
2. hover anywhere over the OAS EE project card
3. note the cursor changes to a pointer, the link brightens and loses its underline
4. click anywhere within the project card, expect to navigate to that projects home page

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
