### PR TITLE
Incremental Static Regeneration

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -177,5 +177,6 @@ export const getStaticProps = async ({ locale }) => {
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
       ...(await serverSideTranslations(locale, ["common"])),
     },
+    revalidate: 10,
   };
 };

--- a/pages/home.js
+++ b/pages/home.js
@@ -295,5 +295,6 @@ export const getStaticProps = async ({ locale }) => {
       experimentsData: experimentsData.scLabsPagev1List.items[2],
       ...(await serverSideTranslations(locale, ["common"])),
     },
+    revalidate: 10,
   };
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -197,4 +197,5 @@ export const getStaticProps = async ({ locale }) => ({
     adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
     ...(await serverSideTranslations(locale, ["common"])),
   },
+  revalidate: 10,
 });

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -154,8 +154,9 @@ export default function OasBenefitsEstimator(props) {
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2 gap-4 lg:gap-6">
               <h1 className="text-h1 border-h1-red-bar" id="pageMainTitle">
                 {props.locale === "en"
-                  ? pageData.scTitleEn
-                  : pageData.scTitleFr}
+                  ? pageData.scFragments[0].scContentEn.json[0].content[0].value
+                  : pageData.scFragments[0].scContentFr.json[0].content[0]
+                      .value}
               </h1>
               <div className="row-span-4 p-0 mx-4">
                 <div className="flex justify-center">
@@ -442,5 +443,6 @@ export const getStaticProps = async ({ locale }) => {
       dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),
     },
+    revalidate: 10,
   };
 };

--- a/services/AEMService.js
+++ b/services/AEMService.js
@@ -1,32 +1,29 @@
-const fs = require('fs')
-const path = require('path')
-
-const cacheFilePath = path.resolve('.', 'graphql', '.cache')
+// const cacheFilePath = path.resolve('.', 'graphql', '.cache')
 
 class AEMService {
   constructor(baseUrl, cacheBust) {
-    this.cacheBustString = !!cacheBust?.trim?.()
-      ? cacheBust
-      : new Date().toLocaleDateString("en-CA");
+    // this.cacheBustString = !!cacheBust?.trim?.()
+    //   ? cacheBust
+    //   : new Date().toLocaleDateString("en-CA");
     this.baseUrl = baseUrl;
-    fs.mkdirSync(cacheFilePath, { recursive: true })
-    this.flush()
+    // fs.mkdirSync(cacheFilePath, { recursive: true })
+    // this.flush()
   }
 
   async getFragment(fragId) {
     if (!fragId?.trim?.()) return;
 
-    try {
-      const fileContents = fs.readFileSync(path.resolve(cacheFilePath, `${fragId}.json`))
-      if (fileContents) {
-        const data = JSON.parse(fileContents)
-        console.error("FRAG from cache", fragId)
-        return { data, error: null };
-      }
-    } catch (e) {
-      // console.error(e)
-      console.log(`no cache file for ${fragId}`)
-    }
+    // try {
+    //   const fileContents = fs.readFileSync(path.resolve(cacheFilePath, `${fragId}.json`))
+    //   if (fileContents) {
+    //     const data = JSON.parse(fileContents)
+    //     console.error("FRAG from cache", fragId)
+    //     return { data, error: null };
+    //   }
+    // } catch (e) {
+    //   // console.error(e)
+    //   console.log(`no cache file for ${fragId}`)
+    // }
 
     let headers = new Headers()
     headers.append("Content-Type", "application/json")
@@ -51,18 +48,18 @@ class AEMService {
     }
 
     // if there's no error, store for memoization
-    if (!error && data) {
-      console.log("storing", fragId, "in cache")
-      fs.writeFileSync(path.resolve(cacheFilePath, `${fragId}.json`), JSON.stringify(data));
-    }
+    // if (!error && data) {
+    //   console.log("storing", fragId, "in cache")
+    //   fs.writeFileSync(path.resolve(cacheFilePath, `${fragId}.json`), JSON.stringify(data));
+    // }
 
     return { data, error };
   }
 
-  flush(){
-    fs.rmSync(cacheFilePath, { recursive: true, force: true });
-    fs.mkdirSync(cacheFilePath, { recursive: true })
-  }
+  // flush(){
+  //   fs.rmSync(cacheFilePath, { recursive: true, force: true });
+  //   fs.mkdirSync(cacheFilePath, { recursive: true })
+  // }
 }
 
 module.exports = AEMService;


### PR DESCRIPTION
# Description

This PR is to test out ISR implementation.

Removed the caching in AEMService because it would require us to call aemServiceInstance.flush() in getStaticProps before each request. Additionally, we only make requests once at build-time and all subsequent revalidation requests should not be fetching from cache and instead from the AEM resource for updated content. If this works as-is in dev I will add the revalidate prop to the rest of the pages.

## Acceptance Criteria

If you'd like to see ISR working, you can `yarn build` and then `yarn start` the application locally, then make changes to the OAS Benefits Estimator overview page content within AEM (make sure to do this after running the build). Refreshing the OAS page should show your changes after approximately 10 seconds. Don't forget to revert the content in AEM to their original values.

## Test Instructions

See above.
