### PR TITLE
update content to use data from AEM

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -1649,25 +1649,59 @@ export const homePageData = {
         scPageNameFr: "/fr/accueil",
         scTitleEn: "Service Canada Labs",
         scTitleFr: "Laboratoires de Service Canada",
-        scShortTitleEn: null,
-        scShortTitleFr: null,
+        scShortTitleEn: "Home - Service Canada Labs",
+        scShortTitleFr: "Accueil - Laboratoires de Service Canada",
         scDescriptionEn: {
-          json: null,
+          json: [
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "An early look at what Service Canada is up to. Explore our projects. Share your feedback. Sign-up to get notified of ways to support the future of digital government.",
+                },
+              ],
+            },
+          ],
         },
         scDescriptionFr: {
-          json: null,
+          json: [
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Un aperçu des activités de Service Canada. Explorez nos projets. Faites-nous part de vos commentaires. Inscrivez-vous pour être informé des façons de soutenir l'avenir du gouvernement numérique.",
+                },
+              ],
+            },
+          ],
         },
         scBreadcrumbParentPages: [],
-        scSubject: null,
-        scKeywordsEn: null,
-        scKeywordsFr: null,
+        scSubject: [
+          "gc:subjects/gv-government-and-politics/government-services",
+        ],
+        scKeywordsEn: "digital services",
+        scKeywordsFr: "services numériques",
         scContentType: null,
         scOwner: null,
-        scDateModifiedOverwrite: "2022-12-12",
+        scDateModifiedOverwrite: "2022-12-11",
         scAudience: null,
         scRegion: null,
-        scSocialMediaImageEn: null,
-        scSocialMediaImageFr: null,
+        scSocialMediaImageEn: {
+          _publishUrl:
+            "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+          width: 2932,
+          height: 2078,
+        },
+        scSocialMediaImageFr: {
+          _publishUrl:
+            "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+          width: 2932,
+          height: 2078,
+        },
         scSocialMediaImageAltTextEn: null,
         scSocialMediaImageAltTextFr: null,
         scNoIndex: false,

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useTranslation } from "next-i18next";
 import { Layout } from "../components/organisms/Layout";
 import { useEffect, useState } from "react";
 import Card from "../components/molecules/Card";
@@ -8,7 +7,6 @@ import { Alert } from "../components/atoms/Alert";
 import aemServiceInstance from "../services/aemServiceInstance";
 
 export default function Home(props) {
-  const { t } = useTranslation("common");
   const [pageData] = useState(props.pageData.item);
   const [experimentsData] = useState(props.experimentsData);
 
@@ -23,7 +21,9 @@ export default function Home(props) {
     <>
       <Layout
         locale={props.locale}
-        langUrl={t("homePath")}
+        langUrl={
+          props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
+        }
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
       >
         <Head>
@@ -34,28 +34,57 @@ export default function Home(props) {
           )}
 
           {/* Primary HTML Meta Tags */}
-          <title>{`${t("scLabsHome")} — ${t("siteTitle")}`}</title>
-          <meta name="description" content={`${t("homeMetaDescription")}`} />
+          <title>
+            {props.locale === "en"
+              ? pageData.scShortTitleEn
+              : pageData.scShortTitleFr}
+          </title>
+          <meta
+            name="description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
           <meta name="author" content="Service Canada" />
           <link rel="icon" href="/favicon.ico" />
           <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-          <meta name="keywords" content={t("homeKeywords")} />
+          <meta
+            name="keywords"
+            content={
+              props.locale === "en"
+                ? pageData.scKeywordsEn
+                : pageData.scKeywordsFr
+            }
+          />
 
           {/* DCMI Meta Tags */}
           <meta
             name="dcterms.title"
-            content={`${t("scLabsHome")} — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             name="dcterms.language"
             content={props.locale === "en" ? "eng" : "fra"}
             title="ISO639-2/T"
           />
-          <meta name="dcterms.description" content={t("homeMetaDescription")} />
+          <meta
+            name="dcterms.description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
           <meta
             name="dcterms.subject"
             title="gccore"
-            content={t("metaSubject")}
+            content={pageData.scSubject}
           />
           <meta name="dcterms.creator" content="Service Canada" />
           <meta name="dcterms.accessRights" content="2" />
@@ -73,43 +102,81 @@ export default function Home(props) {
           <meta
             property="og:url"
             content={
-              "https://alpha.service.canada.ca/" +
-              `${props.locale}` +
-              `${t("homeMetaPath")}`
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
             }
           />
           <meta
             property="og:title"
-            content={`${t("scLabsHome")} — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             property="og:description"
-            content={`${t("homeMetaDescription")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
           />
-          <meta property="og:image" content={`${t("metaImage")}`} />
-          <meta property="og:image:alt" content={`${t("siteTitle")}`} />
+          <meta
+            property="og:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="og:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
 
           {/* Twitter */}
           <meta property="twitter:card" content="summary_large_image" />
           <meta
             property="twitter:url"
             content={
-              "https://alpha.service.canada.ca/" +
-              `${props.locale}` +
-              `${t("homeMetaPath")}`
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
             }
           />
           <meta
             property="twitter:title"
-            content={`${t("scLabsHome")} — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta name="twitter:creator" content="Service Canada" />
           <meta
             property="twitter:description"
-            content={`${t("homeMetaDescription")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
           />
-          <meta property="twitter:image" content={`${t("metaImage")}`} />
-          <meta property="twitter:image:alt" content={`${t("siteTitle")}`} />
+          <meta
+            property="twitter:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="twitter:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
         </Head>
         <section className="layout-container mb-24 mt-8">
           <div className="flex">

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -1,6 +1,5 @@
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useTranslation } from "next-i18next";
 import { Layout } from "../../../components/organisms/Layout";
 import { ActionButton } from "../../../components//atoms/ActionButton";
 import { useEffect, useState } from "react";
@@ -9,7 +8,6 @@ import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA } from "@dts-stn/service-canada-design-system";
 
 export default function OasBenefitsEstimator(props) {
-  const { t } = useTranslation(["common", "vc"]);
   const [pageData] = useState(props.pageData.item);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
@@ -66,22 +64,50 @@ export default function OasBenefitsEstimator(props) {
           )}
 
           {/* Primary HTML Meta Tags */}
-          <title>{`${
-            props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
-          } — ${t("siteTitle")}`}</title>
-          <meta name="description" content={`${t("vc:metaDescription")}`} />
+          <title>
+            {props.locale === "en"
+              ? pageData.scShortTitleEn
+              : pageData.scShortTitleFr}
+          </title>
+          <meta
+            name="description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
           <meta name="author" content="Service Canada" />
           <link rel="icon" href="/favicon.ico" />
-          <link rel="canonical" href={t("vc:canonicalURL")} />
+          <link
+            rel="canonical"
+            href={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
           <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-          <meta name="keywords" content={t("vc:keywords")} />
+          <meta
+            name="keywords"
+            content={
+              props.locale === "en"
+                ? pageData.scKeywordsEn
+                : pageData.scKeywordsFr
+            }
+          />
 
           {/* DCMI Meta Tags */}
           <meta
             name="dcterms.title"
-            content={`${
-              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
-            } — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             name="dcterms.language"
@@ -97,23 +123,42 @@ export default function OasBenefitsEstimator(props) {
           <meta name="dcterms.issued" title="W3CDTF" content="2021-07-20" />
 
           <meta name="dcterms.modified" title="W3CDTF" content="2021-12-16" />
-          <meta name="dcterms.description" content={t("vc:metaDescription")} />
+          <meta
+            name="dcterms.description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
           <meta
             name="dcterms.subject"
             title="gccore"
-            content={`${t("vc:metaSubject")}`}
+            content={pageData.scSubject}
           />
           <meta name="dcterms.spatial" content="Canada" />
 
           {/* Open Graph / Facebook */}
           <meta property="og:type" content="website" />
           <meta property="og:locale" content={props.locale} />
-          <meta property="og:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="og:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
           <meta
             property="og:title"
-            content={`${
-              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
-            } — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             property="og:description"
@@ -123,17 +168,37 @@ export default function OasBenefitsEstimator(props) {
                 : pageData.scFragments[0].scContentFr.json[0].content[0].value
             }
           />
-          <meta property="og:image" content={t("metaImage")} />
-          <meta property="og:image:alt" content={t("siteTitle")} />
+          <meta
+            property="og:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="og:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
 
           {/* Twitter */}
           <meta property="twitter:card" content="summary_large_image" />
-          <meta property="twitter:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="twitter:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
           <meta
             property="twitter:title"
-            content={`${
-              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
-            } — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta name="twitter:creator" content="Service Canada" />
           <meta
@@ -144,8 +209,16 @@ export default function OasBenefitsEstimator(props) {
                 : pageData.scFragments[0].scContentFr.json[1].content[0].value
             }
           />
-          <meta property="twitter:image" content={t("metaImage")} />
-          <meta property="twitter:image:alt" content={t("siteTitle")} />
+          <meta
+            property="twitter:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="twitter:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
         </Head>
 
         {/* Virtual Assitant Demo section start -  with link to working prototype */}
@@ -301,7 +374,6 @@ export default function OasBenefitsEstimator(props) {
               <ActionButton
                 id="signup-btn"
                 custom={`py-1.5 px-3 mt-4 md:mt-0 rounded text-[#335075] text-base lg:text-p font-display bg-[#EAEBED] hover:bg-[#CFD1D5] focus:bg-[#CFD1D5] focus:ring-2 focus:ring-[#0E62C9]`}
-                className=""
                 href={
                   props.locale === "en"
                     ? pageData.scFragments[5].scDestinationURLEn


### PR DESCRIPTION
# Description

[Go through application and ensure all strings (if possible) are coming from the CMS](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=111715)

Went through the app noticed the meta data for the home page still comes from local resource files, and part the meta data for the EE page is incorrect and using placeholder. I updated and published the meta data section for both page on AEM and update the app to use those data.  
