### PR TITLE
Add hover state to information links in ProjectInfo.js

### DIFF
--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -37,7 +37,7 @@ export function ProjectInfo(props) {
               />
             </button>
             <button
-              className="text-xs text-[#284162] underline mr-2"
+              className="text-xs text-[#284162] underline mr-2 hover:text-custom-blue-link"
               onClick={() => setShowInfo(!showInfo)}
               aria-label="project stage detail"
               aria-expanded={showInfo}


### PR DESCRIPTION
# Description

Added a hover state to the "Information" button/link in the ProjectInfo component.

Normal State
![Screenshot 2023-03-21 at 8 30 13 AM](https://user-images.githubusercontent.com/31868510/226656537-dbb2579e-8fa2-4518-a13a-f6da698d45d4.png)

Hover state
![Screenshot 2023-03-21 at 8 31 06 AM](https://user-images.githubusercontent.com/31868510/226656772-b9ee68e0-d8f6-46b5-9a58-d6346f35f1b0.png)


## Acceptance Criteria

Button/link should have a hover state like other links on the site.

## Test Instructions

1. Hover over the "Information" button/link on the OAS Estimator  page
