### PR TITLE
"Try the estimator" and "Give feedback" buttons single column on mobile

### DIFF
--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -354,11 +354,11 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[0].scContentEn.json[9].content[0].value
                 : pageData.scFragments[0].scContentFr.json[9].content[0].value}
             </h3>
-            <div className="md:flex">
+            <div className="grid md:flex">
               <ActionButton
                 id="signup-btn"
-                custom={`py-1.5 px-3 mr-8 rounded text-white text-base lg:text-p font-display bg-custom-blue-dark hover:bg-custom-blue-light border border-custom-blue-darker active:bg-custom-blue-darker hover:ring-2 hover:ring-white`}
-                className=""
+                custom={`py-1.5 px-3 md:mr-8 rounded text-white text-base lg:text-p font-display bg-custom-blue-dark hover:bg-custom-blue-light border border-custom-blue-darker active:bg-custom-blue-darker hover:ring-2 hover:ring-white`}
+                className="text-center"
                 href={
                   props.locale === "en"
                     ? pageData.scFragments[4].scDestinationURLEn
@@ -374,6 +374,7 @@ export default function OasBenefitsEstimator(props) {
               <ActionButton
                 id="signup-btn"
                 custom={`py-1.5 px-3 mt-4 md:mt-0 rounded text-[#335075] text-base lg:text-p font-display bg-[#EAEBED] hover:bg-[#CFD1D5] focus:bg-[#CFD1D5] focus:ring-2 focus:ring-[#0E62C9]`}
+                className="text-center"
                 href={
                   props.locale === "en"
                     ? pageData.scFragments[5].scDestinationURLEn


### PR DESCRIPTION
# Description

The buttons on the OAS page were not responsive on very small displays such as the Galaxy Fold.

<img width="264" alt="Screenshot 2023-03-22 at 11 17 59 AM" src="https://user-images.githubusercontent.com/31868510/227000127-ee260e88-e237-4979-9173-c2d2f8398951.png">

This PR puts the buttons into a single column when the viewport is <550px wide.

<img width="273" alt="Screenshot 2023-03-22 at 11 19 28 AM" src="https://user-images.githubusercontent.com/31868510/227000467-da2b5a68-8fa5-4f4b-ba1e-20e178ede9b8.png">

## Acceptance Criteria

Relevant buttons should be responsive on smaller mobile devices.

## Test Instructions

1. Navigate to OAS Estimator overview page
2. See that "Try the Estimator" and "Give feedback" buttons are responsive on devices <550px wide

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
