### PR TITLE
Adding new endpoint for healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `/signup-review` page where users can review their signup information before final submission for registration
 - Added `check-email` API endpoint for checking if a user exists
 - Added Update/Blog page for Virtual Assistant project updates
+- Added /api/healthcheck endpoint
 
 ## Changed
 

--- a/pages/api/healthcheck.js
+++ b/pages/api/healthcheck.js
@@ -1,0 +1,4 @@
+// TODO: add checks for the status of the CMS
+export default function handler(req, res) {
+  res.status(200).json({ message: "Status OK" });
+}


### PR DESCRIPTION
# Description

[113077 Add healthcheck endpoint for Azure to verify uptime](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=113077)

https://microservices.io/patterns/observability/health-check-api.html

## Test Instructions

1. run `yarn dev`
2. navigate to /api/healthcheck

## Help Requested

- if there are any critical systems that the healthcheck should be aware of besides Adobe Experience Manager, let me know in your review! 

## Checklist

- [x] Update CHANGELOG