### PR TITLE
use font-body class on list items in oas page

### DIFF
--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -327,27 +327,33 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[0].scContentEn.json[7].content[0].value
                 : pageData.scFragments[0].scContentFr.json[7].content[0].value}
             </p>
-            <ul className="list-disc list-outside pl-2 text-sm lg:text-p">
+            <ul className="list-disc list-outside pl-2">
               <li>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[0]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[0]
-                      .content[0].value}
+                <p className="font-body">
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[8].content[0]
+                        .content[0].value
+                    : pageData.scFragments[0].scContentFr.json[8].content[0]
+                        .content[0].value}
+                </p>
               </li>
               <li>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[1]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[1]
-                      .content[0].value}
+                <p className="font-body">
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[8].content[1]
+                        .content[0].value
+                    : pageData.scFragments[0].scContentFr.json[8].content[1]
+                        .content[0].value}
+                </p>
               </li>
               <li>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[2]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[2]
-                      .content[0].value}
+                <p className="font-body">
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[8].content[2]
+                        .content[0].value
+                    : pageData.scFragments[0].scContentFr.json[8].content[2]
+                        .content[0].value}
+                </p>
               </li>
             </ul>
             <h3 className="my-4 mt-8 text-[20px]">
@@ -401,25 +407,31 @@ export default function OasBenefitsEstimator(props) {
           </p>
           <ul className="list-disc list-outside pl-2 text-sm lg:text-p">
             <li>
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[12].content[0]
-                    .content[0].value
-                : pageData.scFragments[0].scContentFr.json[12].content[0]
-                    .content[0].value}
+              <p className="font-body">
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[12].content[0]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[12].content[0]
+                      .content[0].value}
+              </p>
             </li>
             <li>
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[12].content[1]
-                    .content[0].value
-                : pageData.scFragments[0].scContentFr.json[12].content[1]
-                    .content[0].value}
+              <p className="font-body">
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[12].content[1]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[12].content[1]
+                      .content[0].value}
+              </p>
             </li>
             <li>
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[12].content[2]
-                    .content[0].value
-                : pageData.scFragments[0].scContentFr.json[12].content[2]
-                    .content[0].value}
+              <p className="font-body">
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[12].content[2]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[12].content[2]
+                      .content[0].value}
+              </p>
             </li>
           </ul>
           <p className="my-8">

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -327,7 +327,7 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[0].scContentEn.json[7].content[0].value
                 : pageData.scFragments[0].scContentFr.json[7].content[0].value}
             </p>
-            <ul className="list-disc list-outside pl-2 font-body">
+            <ul className="list-disc list-outside pl-2">
               <li>
                 <p>
                   {props.locale === "en"
@@ -405,7 +405,7 @@ export default function OasBenefitsEstimator(props) {
               ? pageData.scFragments[0].scContentEn.json[11].content[0].value
               : pageData.scFragments[0].scContentFr.json[11].content[0].value}
           </p>
-          <ul className="list-disc list-outside pl-2 text-sm lg:text-p font-body">
+          <ul className="list-disc list-outside pl-2">
             <li>
               <p>
                 {props.locale === "en"

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -327,9 +327,9 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[0].scContentEn.json[7].content[0].value
                 : pageData.scFragments[0].scContentFr.json[7].content[0].value}
             </p>
-            <ul className="list-disc list-outside pl-2">
+            <ul className="list-disc list-outside pl-2 font-body">
               <li>
-                <p className="font-body">
+                <p>
                   {props.locale === "en"
                     ? pageData.scFragments[0].scContentEn.json[8].content[0]
                         .content[0].value
@@ -338,7 +338,7 @@ export default function OasBenefitsEstimator(props) {
                 </p>
               </li>
               <li>
-                <p className="font-body">
+                <p>
                   {props.locale === "en"
                     ? pageData.scFragments[0].scContentEn.json[8].content[1]
                         .content[0].value
@@ -347,7 +347,7 @@ export default function OasBenefitsEstimator(props) {
                 </p>
               </li>
               <li>
-                <p className="font-body">
+                <p>
                   {props.locale === "en"
                     ? pageData.scFragments[0].scContentEn.json[8].content[2]
                         .content[0].value
@@ -405,9 +405,9 @@ export default function OasBenefitsEstimator(props) {
               ? pageData.scFragments[0].scContentEn.json[11].content[0].value
               : pageData.scFragments[0].scContentFr.json[11].content[0].value}
           </p>
-          <ul className="list-disc list-outside pl-2 text-sm lg:text-p">
+          <ul className="list-disc list-outside pl-2 text-sm lg:text-p font-body">
             <li>
-              <p className="font-body">
+              <p>
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[12].content[0]
                       .content[0].value
@@ -416,7 +416,7 @@ export default function OasBenefitsEstimator(props) {
               </p>
             </li>
             <li>
-              <p className="font-body">
+              <p>
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[12].content[1]
                       .content[0].value
@@ -425,7 +425,7 @@ export default function OasBenefitsEstimator(props) {
               </p>
             </li>
             <li>
-              <p className="font-body">
+              <p>
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[12].content[2]
                       .content[0].value


### PR DESCRIPTION
# Description

List items on the OAS page are 16px, rather than 20px which is the proper font-size for body content. This PR adds the `font-body` class to the list items to make the font-size 20px.

## Acceptance Criteria

List items on OAS page should be 20px at all viewport sizes

## Test Instructions

1. Navigate to OAS page
2. Inspect list items to see 20px font-size
