### PR TITLE
prevent search indexing of about page

### DIFF
--- a/__tests__/api/robots.test.js
+++ b/__tests__/api/robots.test.js
@@ -23,7 +23,7 @@ describe("robots api", () => {
     });
     await handler(req, res);
     expect(res._getData()).toBe(
-      "User-agent: *\nDisallow: /api\nDisallow: /projects/*\nDisallow: /confirmation.js\nDisallow: /thankyou.js\nDisallow: /notsupported.js\n"
+      "User-agent: *\nDisallow: /api\nDisallow: /projects/*\nDisallow: /confirmation.js\nDisallow: /thankyou.js\nDisallow: /notsupported.js\nDisallow: /about.js\n"
     );
   });
 });

--- a/pages/api/robots.js
+++ b/pages/api/robots.js
@@ -12,6 +12,7 @@ export default async function handler(req, res) {
     res.write("Disallow: /confirmation.js\n");
     res.write("Disallow: /thankyou.js\n");
     res.write("Disallow: /notsupported.js\n");
+    res.write("Disallow: /about.js\n");
   } else {
     res.write("User-agent: *\n");
     res.write("Disallow: /\n");


### PR DESCRIPTION
# Description

This PR prevents the /about page from being indexed for search in Google/Bing etc. 

## Acceptance Criteria

`pages/api/robots.js` should disallow access to `/about.js`.

## Test Instructions

1. Run robots.test.js
2. Tests should succeed
