### PR TITLE
ProjectInfo.js now single column on small displays, FocusTrap behaves more like an accordion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## [v1.5.0] - 2023-04-12
-
 ## Added
 
 ## Changed
+
+- ProjectInfo.js now displays labels and their content in a single column
+- ProjectInfo.js FocusTrap now behaves like an accordion, pushing proceeding content beneath it rather than displaying overtop of it
 
 ## Fixed
 
@@ -214,8 +215,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated robots.txt so that subdirectories of `/projects` won't be indexed by search engines
 - Updated dockerfile to include --legacy-peer-deps on npm installs and rebuilt package-lock.json
-- ProjectInfo.js now displays labels and their content in a single column
-- ProjectInfo.js FocusTrap now behaves like an accordion, pushing proceeding content beneath it rather than displaying overtop of it
 
 ## [v1.0.4] - 2021-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated robots.txt so that subdirectories of `/projects` won't be indexed by search engines
 - Updated dockerfile to include --legacy-peer-deps on npm installs and rebuilt package-lock.json
+- ProjectInfo.js now displays labels and their content in a single column
+- ProjectInfo.js FocusTrap now behaves like an accordion, pushing proceeding content beneath it rather than displaying overtop of it
 
 ## [v1.0.4] - 2021-08-04
 

--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -11,7 +11,7 @@ export function ProjectInfo(props) {
 
   return (
     <>
-      <div className="grid grid-cols-4 gap-x-4 text-[20px]">
+      <div className="grid grid-cols-1 xl:grid-cols-4 gap-x-4 text-[20px]">
         <strong className="col-span-1">{props.termStarted}</strong>
         <p className="col-span-3">
           {!props.dateStarted ? undefined : props.dateStarted.substring(0, 10)}
@@ -45,20 +45,22 @@ export function ProjectInfo(props) {
               {props.information}
             </button>
           </p>
-          {showInfo ? (
+        </div>
+        {showInfo ? (
+          <div className="col-span-3 xl:col-span-4">
             <FocusTrap
               focusTrapOptions={{
                 initialFocus: false,
                 allowOutsideClick: true,
               }}
             >
-              <div className="relative w-full">
+              <div className="w-full">
                 <div
                   style={{
                     background: "#E8F2F4",
                     borderColor: "#269ABC",
                   }}
-                  className="absolute -top-8 border rounded-md px-4 py-2 my-2"
+                  className="border rounded-md px-4 py-2 my-2"
                 >
                   {
                     <>
@@ -74,8 +76,8 @@ export function ProjectInfo(props) {
                 </div>
               </div>
             </FocusTrap>
-          ) : undefined}
-        </div>
+          </div>
+        ) : undefined}
         <strong className="col-span-1">{props.termSummary}</strong>
         <p className="col-span-3">{props.summary}</p>
       </div>


### PR DESCRIPTION
# Description

Ravina Samaroo pointed out that our ProjectInfo component has issues displaying on mobile. Text wraps and gets cut off and the FocusTrap modal gets shoved to the side. You can see the issue here:

![image](https://user-images.githubusercontent.com/31868510/234362137-7de742f6-8e17-4dc5-b964-d607a01f5eac.png)

This PR modifies the ProjectInfo component to make it more responsive on smaller displays, fixing the text wrapping and cutting off of the labels as well as addressing the FocusTrap by changing it's behaviour to more of that of an accordion style where the FocusTrap will appear relative to the content of the component.

![Screenshot 2023-04-25 at 11 23 40 AM](https://user-images.githubusercontent.com/31868510/234367734-a51dd160-51b7-49c8-9b21-6b8e5564b058.png)

This is how it appears on the Galaxy Fold (very small displays):

![Screenshot 2023-04-25 at 11 24 37 AM](https://user-images.githubusercontent.com/31868510/234367952-458e1999-7f01-46d6-b6d7-0202ed2134dd.png)

## Acceptance Criteria

ProjectInfo component should be responsive, legible and accessible across viewport sizes. 

## Test Instructions

1. yarn dev
2. navigate to OAS page
3. With viewport set to 280px width, see that content displays legibly and that the FocusTrap when opened properly displays as in the screenshot.
4. Check responsiveness on larger displays up to desktop. Content should be legible.

## Checklist

- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG
