### PR TITLE
Unused pages 404 in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## [v1.5.0] - 2023-04-12
-
 ## Added
 
 ## Changed
+
+- Hid project pages without links on the main page
 
 ## Fixed
 

--- a/next.config.js
+++ b/next.config.js
@@ -243,11 +243,6 @@ module.exports = {
         permanent: false,
       },
       {
-        source: "/projects",
-        destination: "/home",
-        permanent: false,
-      },
-      {
         source: "/signup",
         has: [
           {
@@ -353,6 +348,16 @@ module.exports = {
           },
         ],
         destination: "/notsupported",
+        permanent: false,
+      },
+      {
+        source: "/projects",
+        destination: "/home",
+        permanent: false,
+      },
+      {
+        source: "/projets",
+        destination: "/home",
         permanent: false,
       },
     ];

--- a/pages/projects/digital-centre.js
+++ b/pages/projects/digital-centre.js
@@ -866,6 +866,12 @@ export default function DigitalCenter(props) {
 
 export const getStaticProps = async ({ locale }) => {
   const { data } = await aemServiceInstance.getFragment("digitalCentreQuery");
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
   return {
     props: {
       locale: locale,

--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -388,6 +388,12 @@ export default function LifeJourneys(props) {
 
 export const getStaticProps = async ({ locale }) => {
   const { data } = await aemServiceInstance.getFragment("havingAChildQuery");
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
   return {
     props: {
       locale: locale,

--- a/pages/projects/virtual-assistant/[id].js
+++ b/pages/projects/virtual-assistant/[id].js
@@ -238,6 +238,12 @@ export const getStaticProps = async ({ locale, params }) => {
   const pageData = pages.filter((page) => {
     return page.scPageNameEn === params.id || page.scPageNameFr === params.id;
   });
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
   return {
     props: {
       locale: locale,

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -361,7 +361,12 @@ export const getStaticProps = async ({ locale }) => {
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
   return {
     props: {
       locale: locale,

--- a/pages/projects/virtual-assistant/try-it-out.js
+++ b/pages/projects/virtual-assistant/try-it-out.js
@@ -499,7 +499,12 @@ export const getStaticProps = async ({ locale }) => {
   const { data } = await aemServiceInstance.getFragment(
     "tryVirtualAssistantQuery"
   );
-
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
   return {
     props: {
       locale: locale,


### PR DESCRIPTION
# Description

Just removing the ability to navigate to projects that arent included in SC Labs any more

## Test Instructions

1. set ENVIRONMENT=production in your .env
2. yarn build and yarn start
3. navigate to http://localhost:3000/en/projects/life-journeys
4. navigate to http://localhost:3000/en/projects/digital-centre
5. navigate to http://localhost:3000/en/projects/virtual-assistant
6. verify the above links all lead to the 404 page

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[ADO](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)
