### PR TITLE
Card.js can be right-clicked to open a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - ProjectInfo.js now displays labels and their content in a single column
 - ProjectInfo.js FocusTrap now behaves like an accordion, pushing proceeding content beneath it rather than displaying overtop of it
 - Hid project pages without links on the main page
+- Right-clicking anywhere on Card.js allows to open the link in a new tab
 
 ## Fixed
 

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -15,7 +15,7 @@ export const Card = (props) => {
   };
 
   return (
-    <Link href={props.href} legacyBehavior>
+    <Link href={props.href}>
       <div
         className={`group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
           "border-" + (tagColours[props.tag] || "gray-experiment")


### PR DESCRIPTION
# Description

This task addresses the issue of not being able to right-click anywhere on the Card.js and open a new tab. By removing the [legacyBehaviour](https://nextjs.org/docs/pages/api-reference/components/link#legacybehavior) prop from the `<Link>` tag in the component users can now right click on the card for the expected behaviour.

## Acceptance Criteria

Right-clicking anywhere on the card should give the option to open in a new tab.

## Test Instructions

1. Navigate to the home page
2. Right-click anywhere on the card
3. Yo should see the option to open in a new tab clicking anywhere on the card

## Checklist

- [x] Update CHANGELOG
