### PR TITLE
Remove nested anchor from Card.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - ProjectInfo.js FocusTrap now behaves like an accordion, pushing proceeding content beneath it rather than displaying overtop of it
 - Hid project pages without links on the main page
 - Right-clicking anywhere on Card.js allows to open the link in a new tab
+- Remove `<a>` tag nested in another `<a>` from Card.js
 
 ## Fixed
 

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -35,8 +35,8 @@ export const Card = (props) => {
           ""
         )}
         <h2>
-          <a
-            className="block mt-4 text-lg text-custom-blue-projects-link underline px-4 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
+          <p
+            className="block mt-4 font-display text-lg text-custom-blue-projects-link underline px-4 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
             tabIndex="0"
           >
             {props.title}
@@ -51,7 +51,7 @@ export const Card = (props) => {
             ) : (
               ""
             )}
-          </a>
+          </p>
           {props.showDate ? (
             <p className="ml-4 text-base text-custom-gray-date">
               {"Posted: " + props.datePosted.substring(0, 10)}


### PR DESCRIPTION
# Description

Previous change to the Card.js component to allow right clicking to open a new tab across the component created an error with nested `<a>` tags. Essentially it's bad html to have an `<a>` tag nested within another `<a>`. This PR fixes the issue by replacing the unnecessary nested `<a>` tag with a `<p>` tag. Behaviour and appearance remains the same.

## Acceptance Criteria

Card should appear and behave the same way as before, without errors of bad html formatting in the console.

## Test Instructions

1. Navigate to the home page
2. Check the console for errors related to nested `<a>` tags. There should be none.
3. Right-clicking anywhere on the component should let you open a new tab

## Checklist

- [x] Update CHANGELOG
