### PR TITLE
Signup privacy page returns 404 in prod

### DIFF
--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -458,6 +458,14 @@ export default function Privacy(props) {
 
 export const getStaticProps = async ({ locale }) => {
   const { data } = await aemServiceInstance.getFragment("privacyPageQuery");
+
+  // In production, redirect this page to a 404
+  if (process.env.ENVIRONMENT === "production") {
+    return {
+      notFound: true,
+    };
+  }
+
   return {
     props: {
       locale: locale,


### PR DESCRIPTION
# Hide old SC Labs pages

This PR makes the Signup privacy page unavailable in production.

## Test Instructions

1. set ENVIRONMENT variable to `production`
2. Navigate to /signup/privacy
3. Page should return 404

## Definition of Done

Signup privacy page should 404
