### PR TITLE
125816 Fixing heading spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- margin-bottom: 24px to headings h1 through h5
+
 ## Changed
 
 - Small changes to Card.js

--- a/pages/home.js
+++ b/pages/home.js
@@ -182,7 +182,7 @@ export default function Home(props) {
           <div className="flex">
             <div id="header-text">
               <h1
-                className="font-display pb-6 text-h1 font-bold"
+                className="font-display text-h1 font-bold"
                 tabIndex="-1"
                 id="pageMainTitle"
               >
@@ -219,9 +219,9 @@ export default function Home(props) {
               />
             </span>
           </div>
-          <div className="mb-10 lg:flex">
+          <div className="lg:flex">
             <span className="w-full">
-              <h2 className="mt-8 mb-8 text-h1l">
+              <h2 className="mt-12 text-h1l">
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[3].content[0].value
                   : pageData.scFragments[0].scContentFr.json[3].content[0]
@@ -255,7 +255,7 @@ export default function Home(props) {
               </ul>
             </span>
           </div>
-          <h2 className="text-h1l pb-6">
+          <h2 className="text-h1l mt-12">
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[6].content[0].value
               : pageData.scFragments[0].scContentFr.json[6].content[0]

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -395,7 +395,7 @@ export default function OasBenefitsEstimator(props) {
               />
             </div>
           </div>
-          <h2 className="my-8">
+          <h2 className="mt-12">
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[10].content[0].value
               : pageData.scFragments[0].scContentFr.json[10].content[0].value}
@@ -444,7 +444,7 @@ export default function OasBenefitsEstimator(props) {
               ? pageData.scFragments[0].scContentEn.json[14].content[0].value
               : pageData.scFragments[0].scContentFr.json[14].content[0].value}
           </p>
-          <h2 className="my-8">
+          <h2 className="mt-12">
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[15].content[0].value
               : pageData.scFragments[0].scContentFr.json[15].content[0].value}

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -311,89 +311,87 @@ export default function OasBenefitsEstimator(props) {
               />
             </div>
           </main>
-          <div className="my-8">
-            <h2>
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[5].content[0].value
-                : pageData.scFragments[0].scContentFr.json[5].content[0].value}
-            </h2>
-            <p>
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[6].content[0].value
-                : pageData.scFragments[0].scContentFr.json[6].content[0].value}
-            </p>
-            <p className="my-4">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[7].content[0].value
-                : pageData.scFragments[0].scContentFr.json[7].content[0].value}
-            </p>
-            <ul className="list-disc list-outside pl-2">
-              <li>
-                <p>
-                  {props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[8].content[0]
-                        .content[0].value
-                    : pageData.scFragments[0].scContentFr.json[8].content[0]
-                        .content[0].value}
-                </p>
-              </li>
-              <li>
-                <p>
-                  {props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[8].content[1]
-                        .content[0].value
-                    : pageData.scFragments[0].scContentFr.json[8].content[1]
-                        .content[0].value}
-                </p>
-              </li>
-              <li>
-                <p>
-                  {props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[8].content[2]
-                        .content[0].value
-                    : pageData.scFragments[0].scContentFr.json[8].content[2]
-                        .content[0].value}
-                </p>
-              </li>
-            </ul>
-            <h3 className="my-4 mt-8 text-[20px]">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[9].content[0].value
-                : pageData.scFragments[0].scContentFr.json[9].content[0].value}
-            </h3>
-            <div className="grid md:flex">
-              <ActionButton
-                id="try-btn"
-                style="primary"
-                custom="mb-4 md:mb-0 md:mr-8"
-                href={
-                  props.locale === "en"
-                    ? pageData.scFragments[4].scDestinationURLEn
-                    : pageData.scFragments[4].scDestinationURLFr
-                }
-                text={
-                  props.locale === "en"
-                    ? pageData.scFragments[4].scTitleEn
-                    : pageData.scFragments[4].scTitleFr
-                }
-                ariaExpanded={props.ariaExpanded}
-              />
-              <ActionButton
-                id="feedback-btn-2"
-                style="secondary"
-                href={
-                  props.locale === "en"
-                    ? pageData.scFragments[5].scDestinationURLEn
-                    : pageData.scFragments[5].scDestinationURLFr
-                }
-                text={
-                  props.locale === "en"
-                    ? pageData.scFragments[5].scTitleEn
-                    : pageData.scFragments[5].scTitleFr
-                }
-                ariaExpanded={props.ariaExpanded}
-              />
-            </div>
+          <h2 className="mt-12">
+            {props.locale === "en"
+              ? pageData.scFragments[0].scContentEn.json[5].content[0].value
+              : pageData.scFragments[0].scContentFr.json[5].content[0].value}
+          </h2>
+          <p>
+            {props.locale === "en"
+              ? pageData.scFragments[0].scContentEn.json[6].content[0].value
+              : pageData.scFragments[0].scContentFr.json[6].content[0].value}
+          </p>
+          <p className="my-4">
+            {props.locale === "en"
+              ? pageData.scFragments[0].scContentEn.json[7].content[0].value
+              : pageData.scFragments[0].scContentFr.json[7].content[0].value}
+          </p>
+          <ul className="list-disc list-outside pl-2">
+            <li>
+              <p>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[8].content[0]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[8].content[0]
+                      .content[0].value}
+              </p>
+            </li>
+            <li>
+              <p>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[8].content[1]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[8].content[1]
+                      .content[0].value}
+              </p>
+            </li>
+            <li>
+              <p>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[8].content[2]
+                      .content[0].value
+                  : pageData.scFragments[0].scContentFr.json[8].content[2]
+                      .content[0].value}
+              </p>
+            </li>
+          </ul>
+          <h3 className="my-4 mt-8 text-[20px]">
+            {props.locale === "en"
+              ? pageData.scFragments[0].scContentEn.json[9].content[0].value
+              : pageData.scFragments[0].scContentFr.json[9].content[0].value}
+          </h3>
+          <div className="grid md:flex">
+            <ActionButton
+              id="try-btn"
+              style="primary"
+              custom="mb-4 md:mb-0 md:mr-8"
+              href={
+                props.locale === "en"
+                  ? pageData.scFragments[4].scDestinationURLEn
+                  : pageData.scFragments[4].scDestinationURLFr
+              }
+              text={
+                props.locale === "en"
+                  ? pageData.scFragments[4].scTitleEn
+                  : pageData.scFragments[4].scTitleFr
+              }
+              ariaExpanded={props.ariaExpanded}
+            />
+            <ActionButton
+              id="feedback-btn-2"
+              style="secondary"
+              href={
+                props.locale === "en"
+                  ? pageData.scFragments[5].scDestinationURLEn
+                  : pageData.scFragments[5].scDestinationURLFr
+              }
+              text={
+                props.locale === "en"
+                  ? pageData.scFragments[5].scTitleEn
+                  : pageData.scFragments[5].scTitleFr
+              }
+              ariaExpanded={props.ariaExpanded}
+            />
           </div>
           <h2 className="mt-12">
             {props.locale === "en"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,7 @@ html {
   h4,
   h5 {
     @apply font-display font-semibold;
+    margin-bottom: 24px;
   }
   h6 {
     @apply font-display;
@@ -92,11 +93,11 @@ html {
   }
 
   .textbuttonField > h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  .textbuttonField > h2,
+  .textbuttonField > h3,
+  .textbuttonField > h4,
+  .textbuttonField > h5,
+  .textbuttonField > h6 {
     @apply mb-4;
   }
 


### PR DESCRIPTION
# [125816 Fixing heading spacing](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=125816)

- Changed defaults on al headings to apply margin-bottom: 24px per design
- Applied tailwind class mt-12 (margin-top: 48px) to all headings excluding the first on each page

## Test Instructions

1. Go to home page, see that spacing around headings reflects design [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=14266-32495&t=0BpoYhrs7RER8MWG-0)
2. Go to OAS page, see that headings follow the same design

## Definition of Done

- [x] Update CHANGELOG
