### PR TITLE
125813 Update heading image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Increased paragraph tag line-height to 33px
 - Small changes to Card.js
 
 ## Fixed

--- a/pages/home.js
+++ b/pages/home.js
@@ -206,7 +206,7 @@ export default function Home(props) {
             </div>
             <span
               className="hidden xl:flex w-full lg:ml-8"
-              style={{ height: "320px", width: "500px", minWidth: "500px" }}
+              style={{ height: "300px", width: "431px", minWidth: "431px" }}
               role="presentation"
             >
               <img

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,7 +42,7 @@ module.exports = {
       sm: ["16px", "22px"],
       base: ["18px", "28px"],
       lg: ["20px", "32px"],
-      p: ["20px", "30px"],
+      p: ["20px", "33px"],
       h4: ["22px", "20px"],
       h3: ["24px", "24.3px"],
       h2: ["30px", "33.5px"],


### PR DESCRIPTION
# [125813 Update heading image](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=125813)

- Reduce size of heading image
- Increase `<p>` line-height to 33px per design

<img width="1189" alt="Screenshot 2023-06-21 at 10 47 15 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/27e6accb-899e-4f02-b2c4-223242494909">

## Test Instructions

1. Go to homepage and see that image renders at a reduced size of 431px by 300px

## Definition of Done

- [x] Update CHANGELOG
