### PR TITLE
General design updates

### DIFF
--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -12,15 +12,15 @@ export function ProjectInfo(props) {
   return (
     <>
       <div className="grid grid-cols-1 xl:grid-cols-4 gap-x-4 text-[20px]">
-        <strong className="col-span-1">{props.termStarted}</strong>
+        <strong className="font-body col-span-1">{props.termStarted}</strong>
         <p className="col-span-3">
           {!props.dateStarted ? undefined : props.dateStarted.substring(0, 10)}
         </p>
-        <strong className="col-span-1">{props.termEnded}</strong>
+        <strong className="font-body col-span-1">{props.termEnded}</strong>
         <p className="col-span-3">
           {!props.dateEnded ? undefined : props.dateEnded.substring(0, 10)}
         </p>
-        <strong className="col-span-1">{props.termStage}</strong>
+        <strong className="font-body col-span-1">{props.termStage}</strong>
         <div className="flex col-span-3 items-end">
           <p className="shrink-0 flex">
             {props.stage}
@@ -78,7 +78,7 @@ export function ProjectInfo(props) {
             </FocusTrap>
           </div>
         ) : undefined}
-        <strong className="col-span-1">{props.termSummary}</strong>
+        <strong className="font-body col-span-1">{props.termSummary}</strong>
         <p className="col-span-3">{props.summary}</p>
       </div>
     </>

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -34,32 +34,30 @@ export const Card = (props) => {
         ) : (
           ""
         )}
-        <h2>
-          <p
-            className="block font-display text-lg text-custom-blue-projects-link underline underline-offset-4 mt-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
-            tabIndex="0"
-          >
-            {props.title}
-            {props.showIcon ? (
-              props.href.substring(0, 8) === "https://" ? (
-                <div className="h-4 w-4 ml-1 mt-1 relative">
-                  <img src={props.icon} alt={props.iconAlt} />
-                </div>
-              ) : (
-                ""
-              )
+        <p
+          className="block font-display text-lg text-custom-blue-projects-link font-bold underline underline-offset-4 my-1 py-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
+          tabIndex="0"
+        >
+          {props.title}
+          {props.showIcon ? (
+            props.href.substring(0, 8) === "https://" ? (
+              <div className="h-4 w-4 ml-1 mt-1 relative">
+                <img src={props.icon} alt={props.iconAlt} />
+              </div>
             ) : (
               ""
-            )}
-          </p>
-          {props.showDate ? (
-            <p className="ml-6 text-base text-custom-gray-date">
-              {"Posted: " + props.datePosted.substring(0, 10)}
-            </p>
+            )
           ) : (
             ""
           )}
-        </h2>
+        </p>
+        {props.showDate ? (
+          <p className="ml-6 text-base text-custom-gray-date">
+            {"Posted: " + props.datePosted.substring(0, 10)}
+          </p>
+        ) : (
+          ""
+        )}
         {props.showTag ? (
           <span
             className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ml-6 ${

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -101,8 +101,8 @@ export const Layout = ({
           </div>
         </div>
 
-        <div className="mb-2 border-t pb-2 mt-4">
-          <div className="layout-container mt-10 mb-12">
+        <div className="border-t pb-2 mt-4">
+          <div className="layout-container mt-10 mb-2">
             <Breadcrumb items={breadcrumbItems} />
           </div>
         </div>
@@ -115,7 +115,7 @@ export const Layout = ({
         <div>{children}</div>
       </main>
 
-      <footer>
+      <footer className="mt-12">
         <h2 className="sr-only">{t("siteFooter")}</h2>
         <div className="layout-container mt-5">
           <ReportAProblem />

--- a/pages/home.js
+++ b/pages/home.js
@@ -179,11 +179,10 @@ export default function Home(props) {
             }
           />
         </Head>
-        <section className="layout-container mb-24 mt-8">
+        <section className="layout-container">
           <div className="flex">
             <div id="header-text">
               <Heading
-                className="mb-8"
                 tabIndex="-1"
                 id="pageMainTitle"
                 title={
@@ -224,7 +223,7 @@ export default function Home(props) {
           </div>
           <div className="lg:flex">
             <span className="w-full">
-              <h2 className="mt-12">
+              <h2>
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[3].content[0].value
                   : pageData.scFragments[0].scContentFr.json[3].content[0]
@@ -258,7 +257,7 @@ export default function Home(props) {
               </ul>
             </span>
           </div>
-          <h2 className="mt-12">
+          <h2>
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[6].content[0].value
               : pageData.scFragments[0].scContentFr.json[6].content[0]

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import aemServiceInstance from "../../../services/aemServiceInstance";
 import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA } from "@dts-stn/service-canada-design-system";
+import { Heading } from "@dts-stn/service-canada-design-system";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -223,15 +224,20 @@ export default function OasBenefitsEstimator(props) {
         </Head>
 
         {/* Virtual Assitant Demo section start -  with link to working prototype */}
-        <section className="layout-container my-8">
+        <section className="layout-container">
           <main aria-labelledby="pageMainTitle">
-            <div className="flex flex-col break-words lg:grid lg:grid-cols-2 gap-4 lg:gap-6">
-              <h1 className="text-h1 border-h1-red-bar" id="pageMainTitle">
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[0].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[0].content[0]
-                      .value}
-              </h1>
+            <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
+              <Heading
+                tabIndex="-1"
+                id="pageMainTitle"
+                title={
+                  props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[0].content[0]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[0].content[0]
+                        .value
+                }
+              />
               <div className="row-span-4 p-0 mx-4">
                 <div className="flex justify-center">
                   <div className="object-fill h-auto w-auto max-w-450px">
@@ -252,7 +258,7 @@ export default function OasBenefitsEstimator(props) {
                   </div>
                 </div>
               </div>
-              <p className="font-body text-lg">
+              <p className="font-body text-lg mb-4">
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[1].content[0].value
                   : pageData.scFragments[0].scContentFr.json[1].content[0]
@@ -311,7 +317,7 @@ export default function OasBenefitsEstimator(props) {
               />
             </div>
           </main>
-          <h2 className="mt-12">
+          <h2>
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[5].content[0].value
               : pageData.scFragments[0].scContentFr.json[5].content[0].value}
@@ -393,7 +399,7 @@ export default function OasBenefitsEstimator(props) {
               ariaExpanded={props.ariaExpanded}
             />
           </div>
-          <h2 className="mt-12">
+          <h2>
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[10].content[0].value
               : pageData.scFragments[0].scContentFr.json[10].content[0].value}
@@ -442,17 +448,17 @@ export default function OasBenefitsEstimator(props) {
               ? pageData.scFragments[0].scContentEn.json[14].content[0].value
               : pageData.scFragments[0].scContentFr.json[14].content[0].value}
           </p>
-          <h2 className="mt-12">
+          <h2>
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[15].content[0].value
               : pageData.scFragments[0].scContentFr.json[15].content[0].value}
           </h2>
-          <p className="my-8">
+          <p className="mb-8">
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[16].content[0].value
               : pageData.scFragments[0].scContentFr.json[16].content[0].value}
           </p>
-          <div className="md:flex">
+          <div className="md:flex mb-12">
             <ActionButton
               id="feedback-btn-2"
               style="secondary"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -17,6 +17,7 @@ html {
   h4,
   h5 {
     @apply font-display font-semibold;
+    margin-top: 48px;
     margin-bottom: 24px;
   }
   h6 {


### PR DESCRIPTION
# General design updates

- [ProjectInfo should use font-body for labels](https://github.com/DTS-STN/Service-Canada-Labs/commit/be3938ec3f11d871059e018c08b4526e3a8528c8)
- [Card.js now uses p tag for "link" text to avoid default header styles](https://github.com/DTS-STN/Service-Canada-Labs/commit/0ed4b8be2bc3abc736ba384d7bc7e31b5860d8ce)
- [add default margin-top to footer, reduce margin beneath breadcrumbs](https://github.com/DTS-STN/Service-Canada-Labs/commit/50f515b7f5381f6b4cc36093d7102260a65ad84a)
- [remove unnecessary margin and related classes](https://github.com/DTS-STN/Service-Canada-Labs/commit/f9bee04f5621c14b06e2e93ac95bb7406164275c)
- [modify spacing across page, use SCDS Heading component for main heading](https://github.com/DTS-STN/Service-Canada-Labs/commit/b126522b85a386ff01c400e82addb65cf31b5b46)
- [add default top margin to all headings except h6](https://github.com/DTS-STN/Service-Canada-Labs/commit/2360f635e06a727f144983c36a5f2553bc9d40c6)

## Test Instructions

1. Changes should match design updates found [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=14273-32501&mode=design&t=N9DojjjHRFTdrA34-0)
