### PR TITLE
Fix positioning of heading images on homepage and OAS page

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -207,7 +207,7 @@ export default function Home(props) {
               </p>
             </div>
             <span
-              className="hidden xl:flex w-full lg:ml-8"
+              className="hidden xl:flex w-full lg:ml-8 mt-auto"
               style={{ height: "300px", width: "431px", minWidth: "431px" }}
               role="presentation"
             >

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -239,7 +239,7 @@ export default function OasBenefitsEstimator(props) {
                 }
               />
               <div className="row-span-4 p-0 mx-4">
-                <div className="flex justify-center">
+                <div className="flex justify-center lg:mt-14">
                   <div className="object-fill h-auto w-auto max-w-450px">
                     <img
                       src={


### PR DESCRIPTION
# Fix positioning of heading images on home and OAS

After the changes to default spacing of headers and other elements, the images on the home page and OAS page ended up being higher on the page than they should be. This PR fixes this so that they match design.

**Homepage**

**Before:**

<img width="1193" alt="Screenshot 2023-06-28 at 1 34 41 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/7b99abfc-5dfa-4f19-8083-3dd303cd5ae9">

**After:**

<img width="1235" alt="Screenshot 2023-06-28 at 1 35 28 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/d3124d80-a87a-49f2-b8a5-d932afe4c72e">

**OAS Page**

**Before:**

<img width="1210" alt="Screenshot 2023-06-28 at 1 36 26 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/c48df9f6-cb4f-4c10-b3f6-73736354eda0">

**After:**

<img width="1221" alt="Screenshot 2023-06-28 at 1 36 47 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/d012b56e-e97c-453d-8b9b-d6c1bae6e18b">


## Test Instructions

1. See that home page and OAS page have their images in a place that matches design [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=11385-29412&mode=design&t=N9DojjjHRFTdrA34-0)
