### PR TITLE
Home page and OAS page Heading design updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Small changes to Card.js
 - Increased h3 line-height
 - Removed class overriding default border colour on Card.js
+- Updated headings sections to match new design with image under main H1
 
 ## Fixed
 

--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -11,17 +11,17 @@ export function ProjectInfo(props) {
 
   return (
     <>
-      <div className="grid grid-cols-1 xl:grid-cols-4 gap-x-4 text-[20px]">
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-x-2 text-[20px]">
         <strong className="font-body col-span-1">{props.termStarted}</strong>
-        <p className="col-span-3">
+        <p className="col-span-2">
           {!props.dateStarted ? undefined : props.dateStarted.substring(0, 10)}
         </p>
         <strong className="font-body col-span-1">{props.termEnded}</strong>
-        <p className="col-span-3">
+        <p className="col-span-2">
           {!props.dateEnded ? undefined : props.dateEnded.substring(0, 10)}
         </p>
         <strong className="font-body col-span-1">{props.termStage}</strong>
-        <div className="flex col-span-3 items-end">
+        <div className="flex col-span-2 items-end">
           <p className="shrink-0 flex">
             {props.stage}
             <button
@@ -79,7 +79,7 @@ export function ProjectInfo(props) {
           </div>
         ) : undefined}
         <strong className="font-body col-span-1">{props.termSummary}</strong>
-        <p className="col-span-3">{props.summary}</p>
+        <p className="col-span-2">{props.summary}</p>
       </div>
     </>
   );

--- a/pages/home.js
+++ b/pages/home.js
@@ -180,8 +180,8 @@ export default function Home(props) {
           />
         </Head>
         <section className="layout-container">
-          <div className="flex">
-            <div id="header-text">
+          <div className="grid grid-cols-4">
+            <div className="col-span-4">
               <Heading
                 tabIndex="-1"
                 id="pageMainTitle"
@@ -193,33 +193,35 @@ export default function Home(props) {
                         .value
                 }
               />
-              <p className="font-body">
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[1].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[1].content[0]
-                      .value}
-              </p>
-              <p className="font-body pt-6">
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[2].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[2].content[0]
-                      .value}
-              </p>
             </div>
-            <span
-              className="hidden xl:flex w-full lg:ml-8 mt-auto"
-              style={{ height: "300px", width: "431px", minWidth: "431px" }}
-              role="presentation"
-            >
-              <img
-                src={
-                  props.locale === "en"
-                    ? pageData.scFragments[1].scImageEn._publishUrl
-                    : pageData.scFragments[1].scImageFr._publishUrl
-                }
-                alt=""
-              />
-            </span>
+            <p className="font-body col-span-4 xl:col-span-2 row-start-2">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[1].content[0].value
+                : pageData.scFragments[0].scContentFr.json[1].content[0].value}
+            </p>
+            <p className="font-body col-span-4 xl:col-span-2 row-start-3 pt-4 xxl:pt-0">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[2].content[0].value
+                : pageData.scFragments[0].scContentFr.json[2].content[0].value}
+            </p>
+            <div className="hidden xl:grid col-span-2 col-start-3 row-start-2 row-span-2">
+              <div className="flex justify-center">
+                <span
+                  className="w-full"
+                  style={{ height: "260px", width: "380px", minWidth: "380px" }}
+                  role="presentation"
+                >
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[1].scImageEn._publishUrl
+                        : pageData.scFragments[1].scImageFr._publishUrl
+                    }
+                    alt=""
+                  />
+                </span>
+              </div>
+            </div>
           </div>
           <div className="lg:flex">
             <span className="w-full">

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -227,19 +227,21 @@ export default function OasBenefitsEstimator(props) {
         <section className="layout-container">
           <main aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
-              <Heading
-                tabIndex="-1"
-                id="pageMainTitle"
-                title={
-                  props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[0].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[0].content[0]
-                        .value
-                }
-              />
-              <div className="row-span-4 p-0 mx-4">
-                <div className="flex justify-center lg:mt-14">
+              <div className="col-span-2">
+                <Heading
+                  tabIndex="-1"
+                  id="pageMainTitle"
+                  title={
+                    props.locale === "en"
+                      ? pageData.scFragments[0].scContentEn.json[0].content[0]
+                          .value
+                      : pageData.scFragments[0].scContentFr.json[0].content[0]
+                          .value
+                  }
+                />
+              </div>
+              <div className="row-span-2 row-start-2 col-start-2 p-0 mx-4">
+                <div className="flex justify-center">
                   <div className="object-fill h-auto w-auto max-w-450px">
                     <img
                       src={
@@ -258,63 +260,65 @@ export default function OasBenefitsEstimator(props) {
                   </div>
                 </div>
               </div>
-              <p className="font-body text-lg mb-4">
+              <p className="row-start-2 font-body text-lg mb-4">
                 {props.locale === "en"
                   ? pageData.scFragments[0].scContentEn.json[1].content[0].value
                   : pageData.scFragments[0].scContentFr.json[1].content[0]
                       .value}
               </p>
-              <ProjectInfo
-                termStarted={
-                  props.locale === "en"
-                    ? filteredDictionary[2].scTermEn
-                    : filteredDictionary[2].scTermFr
-                }
-                termStage={
-                  props.locale === "en"
-                    ? filteredDictionary[1].scTermEn
-                    : filteredDictionary[1].scTermFr
-                }
-                termSummary={
-                  props.locale === "en"
-                    ? filteredDictionary[3].scTermEn
-                    : filteredDictionary[3].scTermFr
-                }
-                dateStarted={
-                  pageData.scFragments[0].scContentEn.json[2].content[0].value
-                }
-                term={
-                  props.locale === "en"
-                    ? pageData.scFragments[2].scContentEn.json[0].content[0]
-                        .value
-                    : pageData.scFragments[2].scContentFr.json[0].content[0]
-                        .value
-                }
-                definition={
-                  props.locale === "en"
-                    ? pageData.scFragments[2].scContentEn.json[0].content[1]
-                        .value
-                    : pageData.scFragments[2].scContentFr.json[0].content[1]
-                        .value
-                }
-                information={
-                  props.locale === "en"
-                    ? pageData.scFragments[2].scTitleEn
-                    : pageData.scFragments[2].scTitleFr
-                }
-                stage={
-                  props.locale === "en"
-                    ? stageDictionary.en[pageData.scLabProjectStage]
-                    : stageDictionary.fr[pageData.scLabProjectStage]
-                }
-                summary={
-                  props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[4].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[4].content[0]
-                        .value
-                }
-              />
+              <div className="row-start-3">
+                <ProjectInfo
+                  termStarted={
+                    props.locale === "en"
+                      ? filteredDictionary[2].scTermEn
+                      : filteredDictionary[2].scTermFr
+                  }
+                  termStage={
+                    props.locale === "en"
+                      ? filteredDictionary[1].scTermEn
+                      : filteredDictionary[1].scTermFr
+                  }
+                  termSummary={
+                    props.locale === "en"
+                      ? filteredDictionary[3].scTermEn
+                      : filteredDictionary[3].scTermFr
+                  }
+                  dateStarted={
+                    pageData.scFragments[0].scContentEn.json[2].content[0].value
+                  }
+                  term={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scContentEn.json[0].content[0]
+                          .value
+                      : pageData.scFragments[2].scContentFr.json[0].content[0]
+                          .value
+                  }
+                  definition={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scContentEn.json[0].content[1]
+                          .value
+                      : pageData.scFragments[2].scContentFr.json[0].content[1]
+                          .value
+                  }
+                  information={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scTitleEn
+                      : pageData.scFragments[2].scTitleFr
+                  }
+                  stage={
+                    props.locale === "en"
+                      ? stageDictionary.en[pageData.scLabProjectStage]
+                      : stageDictionary.fr[pageData.scLabProjectStage]
+                  }
+                  summary={
+                    props.locale === "en"
+                      ? pageData.scFragments[0].scContentEn.json[4].content[0]
+                          .value
+                      : pageData.scFragments[0].scContentFr.json[4].content[0]
+                          .value
+                  }
+                />
+              </div>
             </div>
           </main>
           <h2>


### PR DESCRIPTION
# Heading design updates

This PR includes changes to the layout of the heading section of both the home page and the OAS page. Previous design and current implementation were as below:

![Screenshot 2023-07-11 at 12 22 29 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/ccb8c57e-dd46-49b0-913b-289e622a14a3)

These changes modify the two heading sections so that they will appear as in the new design:

![Screenshot 2023-07-11 at 10 51 41 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/cf77ff6b-a7f4-4897-b024-ea0498bd760f)

## Test Instructions

1. Go to home page and OAS pages
2. See that both headings sections match the design of the OAS page shown [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=14752-37343&mode=design&t=IHwNJkTwkeIeurXO-4)

## Definition of Done

- [x] Update CHANGELOG
