### PR TITLE
v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+## Changed
+
+## Fixed
+
+## [v1.6.0] - 2023-07-12
+
+## Added
+
 - margin-bottom: 24px to headings h1 through h5
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-canada-labs",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.15",


### PR DESCRIPTION
# Release PR

## [v1.6.0] - 2023-07-12

## Added

- margin-bottom: 24px to headings h1 through h5

## Changed

- Change heading in home.js to use SCDS Heading component
- Deprecate use of Alert and replaced with SCDS ContextualAlert
- Repositioned homepage Alert
- Update font colour across the site to #333333
- Small changes to Card.js
- Increased h3 line-height
- Removed class overriding default border colour on Card.js
- Updated headings sections to match new design with image under main H1
- Modify font-sizes to align with SCDS responsive sizing

## Fixed


