### PR TITLE
Turn off ISR on OAS page

### DIFF
--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -535,6 +535,6 @@ export const getStaticProps = async ({ locale }) => {
       dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),
     },
-    revalidate: 10,
+    // revalidate: 10,
   };
 };


### PR DESCRIPTION
# Turn off ISR on OAS page

This turns off ISR on the OAS page so that we can avoid conflicts with the new structure of content being delivered from AEM.
