### PR TITLE
Fix ProjectInfo tooltip FocusTrap style so it does not shift content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
+- Fixed issue with tooltip shifting content at some display sizes
+
 ## [v1.6.0] - 2023-07-12
 
 ## Added

--- a/components/atoms/ProjectInfo.js
+++ b/components/atoms/ProjectInfo.js
@@ -47,7 +47,7 @@ export function ProjectInfo(props) {
           </p>
         </div>
         {showInfo ? (
-          <div className="col-span-3 xl:col-span-4">
+          <div className="col-span-1 xl:col-span-3">
             <FocusTrap
               focusTrapOptions={{
                 initialFocus: false,
@@ -78,7 +78,9 @@ export function ProjectInfo(props) {
             </FocusTrap>
           </div>
         ) : undefined}
-        <strong className="font-body col-span-1">{props.termSummary}</strong>
+        <strong className="font-body col-span-1 col-start-1">
+          {props.termSummary}
+        </strong>
         <p className="col-span-2">{props.summary}</p>
       </div>
     </>


### PR DESCRIPTION
# Fix ProjectInfo tooltip FocusTrap style so it does not shift content

This task fixes an issue where due to recent changes in the grid config of the ProjectInfo component, the tooltip content would shift surrounding content and cause unintended behaviour.

Before:

![Screenshot 2023-07-13 at 12 08 42 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/12c78f35-b82f-4055-9f28-74ad06a130cd)

![Screenshot 2023-07-13 at 12 08 54 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/3031fdc4-6e46-427e-b57f-41c570107af4)

After:

![Screenshot 2023-07-13 at 12 09 34 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/a8a49d2c-19c3-4e11-bd7a-2f3c6ff3a257)

![Screenshot 2023-07-13 at 12 10 01 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/a4de0268-0952-4f02-b251-d815ae60f8b1)


## Test Instructions

1. Go to OAS page
2. Open the tooltip
3. Check that there is no strange behaviour or content shifting due to the tooltip at different display sizes

[x] Changelog Updated
