### PR TITLE
OAS Page Design Updates + Blog Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Added OAS update page
+
 ## Changed
+
+- Modified OAS overview page design
+- Added update/blog cards to OAS overview page
 
 ## Fixed
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -8738,3 +8738,859 @@ export const oasBenefitsEstimatorData = {
     },
   },
 };
+
+export const oasUpdatesData = [
+  {
+      "_path": "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/what-we-learned",
+      "scId": "WHAT-WE-LEARNED",
+      "scPageNameEn": "/en/projects/oas-benefits-estimator/what-we-learned",
+      "scPageNameFr": "/fr/projets/estimateur-prestations-sv/ce-que-nous-avons-appris",
+      "scTitleEn": "What we learned on Service Canada Labs before going live on Canada.ca",
+      "scTitleFr": "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca",
+      "scShortTitleEn": null,
+      "scShortTitleFr": null,
+      "scBreadcrumbParentPages": [
+          {
+              "scTitleEn": "Service Canada Labs",
+              "scTitleFr": "Laboratoires de Service Canada",
+              "scPageNameEn": "/en/home",
+              "scPageNameFr": "/fr/accueil"
+          }
+      ],
+      "scSubject": null,
+      "scKeywordsEn": null,
+      "scKeywordsFr": null,
+      "scContentType": null,
+      "scOwner": null,
+      "scDateModifiedOverwrite": "2023-07-07",
+      "scAudience": null,
+      "scRegion": null,
+      "scSocialMediaImageEn": {
+          "_path": "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.png"
+      },
+      "scSocialMediaImageFr": {
+          "_path": "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.png"
+      },
+      "scSocialMediaImageAltTextEn": null,
+      "scSocialMediaImageAltTextFr": null,
+      "scNoIndex": false,
+      "scNoFollow": false,
+      "scFragments": [
+          {
+              "scId": "WHAT-WE-LEARNED",
+              "scImageEn": {
+                  "_publishUrl": "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.png",
+                  "width": 318,
+                  "height": 263
+              },
+              "scImageFr": {
+                  "_publishUrl": "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.png",
+                  "width": 318,
+                  "height": 263
+              },
+              "scImageMobileEn": null,
+              "scImageMobileFr": null,
+              "scImageAltTextEn": "Illustration of two people discussing data",
+              "scImageAltTextFr": " Illustration de deux personnes qui discutent de données",
+              "scImageCaptionEn": {
+                  "json": null
+              },
+              "scImageCaptionFr": {
+                  "json": null
+              }
+          },
+          {
+              "_path": "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/what-we-learned",
+              "scId": "OAS-BENEFITS-ESTIMATOR-WHAT-WE-LEARNED",
+              "scContentEn": {
+                  "json": [
+                      {
+                          "nodeType": "header",
+                          "style": "h1",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "What we learned on Service Canada Labs before going live on Canada.ca"
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "On April 12, 2023, we released an alpha version of the Old Age Security Benefits Estimator to the public. The tool was still in an early development phase, but it was working. We knew the earlier we let everyone use it, the earlier we'd get real feedback. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Since then, over 4,000 people tried it out, and around 200 provided feedback. Here’s what we learned from the feedback collected in our alpha phase, how it’s helping us improve our tool and what’s next for our beta phase. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Asking experts what they think "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Ideally, the estimator could save someone a trip or a call to Service Canada. That's why we wanted to know if it answered the most common questions about Old Age Security benefits. To find out, we asked Service Canada employees. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "They confirmed that the estimator was able to give answers to common questions about: "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "who these benefits are for "
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "how much they can expect to receive "
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "when they can expect to receive a letter from Service Canada "
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "They told us about other questions they get often, and if they found any missing information. Some even gave us ideas to make this tool even more useful for Canadians. We'll be assessing these during our beta phase and will use this information to continuously improve the estimator. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Using data to improve questions "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "We were lucky enough to be able to use data from a similar tool while we were on Service Canada Labs. This helped us gather information about the questions we were asking. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "In alpha, entering an income in the estimator was optional. We wanted to give clients a choice. However, we realized, through our survey, that people were looking for a precise amount in the results. Only providing the maximum income to receive a benefit wasn’t enough. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "The other tool required clients to enter an income. So, we looked at their data. There was nothing to indicate that people didn’t want to do this. The question didn’t stop them from using the tool. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "To give better results, we decided to require income in our beta estimator. This way, we can provide an amount to everyone whose income qualifies, while being confident that the tool is just as easy to use. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Making improvements based on client feedback "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Our main goal for the alpha phase was to get people using the tool and get as much feedback as possible. Anyone who used our tool during our alpha phase could give us their thoughts through an anonymous feedback survey. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "We read all the comments and ratings and found it very valuable. Through our survey, we found out that: "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "90% thought the tool was easy to use "
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "73% were more aware of the benefits available to them "
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Some were satisfied, some had questions, and others wanted to see different features. From the survey responses, we’ve identified the main improvements clients want to see. Many wanted: "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "the ability to get an estimate from a younger age "
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "more clarity about which types of income affect benefits "
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "to have more information about their partner’s results "
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "We’ve already started working on these features and other adjustments. For example, in the beta version now on Canada.ca, we’ve added more detailed and visible results for partners. We’re looking forward to having this improvement and other tweaks make the tool better for Canadians. "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Share your feedback "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "We’re still collecting and addressing feedback! The estimator is still in active development and will be evolving to better meet your needs throughout the beta. Expect to see some changes! "
+                              }
+                          ]
+                      }
+                  ]
+              },
+              "scContentFr": {
+                  "json": [
+                      {
+                          "nodeType": "header",
+                          "style": "h1",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca "
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Le "
+                              },
+                              {
+                                  "nodeType": "span",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "12 avril"
+                                      }
+                                  ],
+                                  "data": {
+                                      "class": "nowrap"
+                                  }
+                              },
+                              {
+                                  "nodeType": "text",
+                                  "value": " 2023, nous avons publié une version alpha de l’Estimateur des prestations de la Sécurité de la vieillesse. L’outil était encore dans une phase de développement préliminaire, mais il fonctionnait. Nous savions que nous pourrions obtenir de la véritable rétroaction plus tôt si nous permettions à tout le monde de l’utiliser. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Depuis, plus de "
+                              },
+                              {
+                                  "nodeType": "span",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "4 000"
+                                      }
+                                  ],
+                                  "data": {
+                                      "class": "nowrap"
+                                  }
+                              },
+                              {
+                                  "nodeType": "text",
+                                  "value": " personnes l’ont essayé et environ 200 ont donné leur rétroaction. Voici ce que nous avons appris des avis recueillis au cours de notre phase alpha, comment ils nous aident à améliorer notre outil et ce qui nous attend pour notre phase bêta. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Demander aux experts ce qu’ils en pensent "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Idéalement, l’estimateur pourrait épargner à quelqu’un un voyage ou un appel à Service Canada. Voilà pourquoi nous voulions savoir s’il répondait aux questions les plus fréquentes sur les prestations de la Sécurité de la vieillesse. Pour le savoir, nous avons consulté les employés de Service Canada. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Ils ont confirmé que l’estimateur répondait aux questions les plus courantes concernan"
+                              },
+                              {
+                                  "nodeType": "span",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "t : "
+                                      }
+                                  ],
+                                  "data": {
+                                      "class": "nowrap"
+                                  }
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "à qui s’adressent ces prestations; "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "le montant qu’ils peuvent s’attendre à recevoir; "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "quand ils peuvent s’attendre à recevoir une lettre de Service Canada. "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Ils nous ont fait part d’autres questions qui leur sont souvent posées et nous ont dit s’ils avaient trouvé des informations manquantes. Certains nous ont même donné des idées pour rendre cet outil encore plus utile pour la population canadienne. Nous évaluerons ces idées au cours de notre phase bêta et nous utiliserons ces informations pour continuer à améliorer l’estimateur. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Utiliser des données pour améliorer les questions "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Nous avions la chance de pouvoir utiliser les données d’un outil similaire lorsque nous étions sur les laboratoires de Service Canada. Cela nous a permis de recueillir des informations sur nos questions. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Dans la version alpha, il était facultatif de saisir un revenu dans I’estimateur. Nous voulions donner le choix aux clients. Cependant, nous nous sommes rendu compte, grâce à notre sondage, que les gens recherchaient un montant précis dans les résultats. Indiquer le revenu maximum pour recevoir une prestation n’était pas suffisant. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "L’autre outil exigeait que les clients entrent un revenu. Nous avons donc examiné leurs données. Rien n’indiquait que les gens ne voulaient pas remplir ce champ. La question ne les empêchait pas d’utiliser l’outil. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Pour fournir de meilleurs résultats, nous avons décidé d’exiger un revenu dans notre estimateur bêta. De cette manière, nous pouvons fournir un montant à toutes les personnes dont le revenu est admissible, tout en étant assurés que l’outil est tout aussi facile à utiliser. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Apporter des améliorations à partir de la rétroaction des clients "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Notre objectif principal pour la phase alpha était d’amener les gens à utiliser l’outil et de recevoir le plus de rétroaction possible. Toute personne ayant utilisé notre outil pendant la phase alpha pouvait nous faire part de ses impressions en répondant à un sondage anonyme. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Nous avons lu tous les commentaires et évaluations et les avons trouvés très utiles. Notre sondage nous a permis de constater qu"
+                              },
+                              {
+                                  "nodeType": "span",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "e :"
+                                      }
+                                  ],
+                                  "data": {
+                                      "class": "nowrap"
+                                  }
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "span",
+                                          "content": [
+                                              {
+                                                  "nodeType": "text",
+                                                  "value": "90 %"
+                                              }
+                                          ],
+                                          "data": {
+                                              "class": "nowrap"
+                                          }
+                                      },
+                                      {
+                                          "nodeType": "text",
+                                          "value": " ont trouvé que l’outil était facile à utiliser; "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "span",
+                                          "content": [
+                                              {
+                                                  "nodeType": "text",
+                                                  "value": "73 %"
+                                              }
+                                          ],
+                                          "data": {
+                                              "class": "nowrap"
+                                          }
+                                      },
+                                      {
+                                          "nodeType": "text",
+                                          "value": " étaient plus conscients des prestations qui leur étaient offertes. "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Certains étaient satisfaits, certains avaient des questions et d’autres voulaient voir d’autres fonctionnalités. À partir des réponses au sondage, nous avons identifié les principales améliorations souhaitées par les clients. De nombreuses personnes voulaien"
+                              },
+                              {
+                                  "nodeType": "span",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "t :"
+                                      }
+                                  ],
+                                  "data": {
+                                      "class": "nowrap"
+                                  }
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "unordered-list",
+                          "content": [
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "pouvoir obtenir une estimation d’un plus jeune âge;   "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "plus de clarté sur les types de revenus qui affectent les prestations;  "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              },
+                              {
+                                  "nodeType": "list-item",
+                                  "content": [
+                                      {
+                                          "nodeType": "text",
+                                          "value": "avoir plus d’information sur les résultats de leur partenaire.   "
+                                      },
+                                      {
+                                          "nodeType": "line-break",
+                                          "content": []
+                                      }
+                                  ]
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Nous avons déjà commencé à travailler sur ces fonctionnalités et sur d’autres ajustements. Par exemple, dans la version bêta actuellement disponible sur Canada.ca, nous avons ajouté des résultats plus détaillés et plus visibles pour les partenaires. Nous avons hâte de voir cette amélioration et d’autres mises à jour améliorer l’outil pour tous. "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "header",
+                          "style": "h2",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Partagez votre avis "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      },
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Nous continuons à recueillir et à intégrer la rétroaction! L’estimateur est encore en développement actif et évoluera pour mieux répondre à vos besoins tout au long de la version bêta. Attendez-vous à voir des changements! "
+                              },
+                              {
+                                  "nodeType": "line-break",
+                                  "content": []
+                              }
+                          ]
+                      }
+                  ]
+              }
+          },
+          {
+              "scId": "GIVE-FEEDBACK-OAS-ESTIMATOR",
+              "scTitleEn": "Give feedback",
+              "scTitleFr": "Fournir des commentaires",
+              "scDestinationURLEn": "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=eng",
+              "scDestinationURLFr": "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=fra",
+              "scButtonType": [
+                  "gc:custom/decd-endc/button-type/secondary"
+              ]
+          },
+          {
+              "scId": "SIGN-UP-FOR-RESEARCH-SESSIONS-OAS-ESTIMATOR",
+              "scTitleEn": "Sign up for research sessions",
+              "scTitleFr": "Inscrivez-vous à des séances de recherche",
+              "scContentEn": {
+                  "json": [
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "If you want to get more involved, fill out our sign up form to let us know you’d like to get invited to our research sessions. We’d love to hear how you think we could improve this tool!"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              "scContentFr": {
+                  "json": [
+                      {
+                          "nodeType": "paragraph",
+                          "content": [
+                              {
+                                  "nodeType": "text",
+                                  "value": "Si vous aimeriez vous impliquer davantage, remplissez notre formulaire d’inscription pour nous indiquer que vous aimeriez vous faire inviter à des séances de recherche. Nous aimerions savoir comment, selon vous, nous pourrions améliorer cet outil!"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              "scImageEn": null,
+              "scImageFr": null,
+              "scFragments": [],
+              "scImageAltTextEn": null,
+              "scImageAltTextFr": null,
+              "scLabsButton": [
+                  {
+                      "scId": "SIGN-UP-FOR-RESEARCH-SESSIONS-OAS-ESTIMATOR",
+                      "scTitleEn": "Sign up",
+                      "scTitleFr": "S'inscrire",
+                      "scDestinationURLEn": "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=ce6dd922-5429-40f4-8619-a4994701f608&lc=eng",
+                      "scDestinationURLFr": "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=ce6dd922-5429-40f4-8619-a4994701f608&lc=fra",
+                      "scButtonType": [
+                          "gc:custom/decd-endc/button-type/primary"
+                      ]
+                  }
+              ]
+          }
+      ]
+  }
+]

--- a/__tests__/pages/oas-benefits-estimator.test.js
+++ b/__tests__/pages/oas-benefits-estimator.test.js
@@ -6,6 +6,7 @@ import OasBenefitsEstimator from "../../pages/projects/oas-benefits-estimator/in
 import {
   dictionaryData,
   oasBenefitsEstimatorData,
+  oasUpdatesData,
 } from "../../__mocks__/mockStore";
 
 describe("OAS Benefits Estimator", () => {
@@ -13,6 +14,7 @@ describe("OAS Benefits Estimator", () => {
     render(
       <OasBenefitsEstimator
         pageData={oasBenefitsEstimatorData.data.scLabsPagev1ByPath}
+        updatesData={oasUpdatesData}
         dictionary={dictionaryData.data.dictionaryV1List}
       />
     );

--- a/graphql/queries/oasBenefitsEstimatorQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorQuery.graphql
@@ -11,11 +11,204 @@ query getOASBenefitsEstimatorPage {
       scShortTitleEn
       scShortTitleFr
       scLabProjectStage
+      scLabProjectSummaryEn {
+        json
+      }
+      scLabProjectSummaryFr {
+        json
+      }
       scDescriptionEn {
         json
       }
       scDescriptionFr {
         json
+      }
+      scLabProjectUpdates {
+        ... on SCLabsPagev1Model {
+          _path
+          scId
+          scPageNameEn
+          scPageNameFr
+          scTitleEn
+          scTitleFr
+          scShortTitleEn
+          scShortTitleFr
+          scBreadcrumbParentPages {
+            ... on SCLabsPagev1Model {
+              scTitleEn
+              scTitleFr
+              scPageNameEn
+              scPageNameFr
+            }
+          }
+          scSubject
+          scKeywordsEn
+          scKeywordsFr
+          scContentType
+          scOwner
+          scDateModifiedOverwrite
+          scAudience
+          scRegion
+          scSocialMediaImageEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scSocialMediaImageFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scSocialMediaImageAltTextEn
+          scSocialMediaImageAltTextFr
+          scNoIndex
+          scNoFollow
+          scFragments {
+            ... on SCLabsContentv1Model {
+              _path
+              scId
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+            }
+            ... on SCLabsImagev1Model {
+              scId
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scImageCaptionEn {
+                json
+              }
+              scImageCaptionFr {
+                json
+              }
+            }
+            ... on SCLabsButtonv1Model {
+              scId
+              scTitleEn
+              scTitleFr
+              scDestinationURLEn
+              scDestinationURLFr
+              scButtonType
+            }
+            ... on SCLabsFeaturev1Model {
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scFragments {
+                ... on SCLabsAlertv1Model {
+                  _path
+                  scId
+                  scTitleEn
+                  scTitleFr
+                  scContentEn {
+                    json
+                  }
+                  scContentFr {
+                    json
+                  }
+                  scAlertType
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scLabsButton {
+                scId
+                scTitleEn
+                scTitleFr
+                scDestinationURLEn
+                scDestinationURLFr
+                scButtonType
+              }
+            }
+            ... on Tooltipv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+            }
+          }
+        }
       }
       scBreadcrumbParentPages {
         ... on SCLabsPagev1Model {

--- a/next.config.js
+++ b/next.config.js
@@ -58,9 +58,13 @@ const REWRITES = [
     destination: "/projects/oas-benefits-estimator",
   },
   {
+    source: "/projets/estimateur-prestations-sv/:slug",
+    destination: "/projects/oas-benefits-estimator/:slug"
+  },
+  {
     source: "/projets/tableau-de-bord",
     destination: "/projects/dashboard"
-  }
+  },
 ];
 
 securityHeaders = [

--- a/pages/home.js
+++ b/pages/home.js
@@ -23,6 +23,13 @@ export default function Home(props) {
     <li key={project.scId} className="list-none">
       <Card
         showImage
+        showTag={
+          project.scTitleEn === "Old Age Security Benefits Estimator"
+            ? true
+            : false
+        }
+        tagLabel={props.locale === "en" ? "New Update" : "Nouvelle mise à jour"}
+        tag="current_projects"
         imgSrc={
           props.locale === "en"
             ? `https://www.canada.ca${project.scSocialMediaImageEn._path}`

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -1,0 +1,430 @@
+import Head from "next/head";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
+import { Layout } from "../../../components/organisms/Layout";
+import { ActionButton } from "../../../components/atoms/ActionButton";
+import { useEffect, useState } from "react";
+import aemServiceInstance from "../../../services/aemServiceInstance";
+import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
+import { CTA, Heading } from "@dts-stn/service-canada-design-system";
+
+export default function OASUpdatePage(props) {
+  const { t } = useTranslation("common", "vc");
+  const [pageData] = useState(props.pageData);
+  const [dictionary] = useState(props.dictionary.items);
+
+  useEffect(() => {
+    console.log(pageData);
+    console.log(dictionary);
+    if (props.adobeAnalyticsUrl) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
+
+  return (
+    <>
+      <Layout
+        locale={props.locale}
+        langUrl={
+          props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
+        }
+        dateModifiedOverride={pageData.scDateModifiedOverwrite}
+        breadcrumbItems={[
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+        ]}
+      >
+        <Head>
+          {props.adobeAnalyticsUrl ? (
+            <script src={props.adobeAnalyticsUrl} />
+          ) : (
+            ""
+          )}
+
+          {/* Primary HTML Meta Tags */}
+          <title>{`${
+            props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+          } — ${t("siteTitle")}`}</title>
+          <meta name="description" content={`${t("vc:metaDescription")}`} />
+          <meta name="author" content="Service Canada" />
+          <link rel="icon" href="/favicon.ico" />
+          <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+          <meta name="keywords" content={t("vc:keywords")} />
+
+          {/* DCMI Meta Tags */}
+          <meta
+            name="dcterms.title"
+            content={`${t("vc:virtualAssistantTitle")} — ${t("siteTitle")}`}
+          />
+          <meta
+            name="dcterms.language"
+            content={props.locale === "en" ? "eng" : "fra"}
+            title="ISO639-2/T"
+          />
+          <meta name="dcterms.description" content={t("homeMetaDescription")} />
+          <meta
+            name="dcterms.subject"
+            title="gccore"
+            content={t("metaSubject")}
+          />
+          <meta name="dcterms.creator" content="Service Canada" />
+          <meta name="dcterms.accessRights" content="2" />
+          <meta
+            name="dcterms.service"
+            content="ESDC-EDSC_SCLabs-LaboratoireSC"
+          />
+          <meta name="dcterms.modified" title="W3CDTF" content="2022-10-05" />
+          <meta name="dcterms.description" content={t("vc:metaDescription")} />
+          <meta
+            name="dcterms.subject"
+            title="gccore"
+            content={`${t("vc:metaSubject")}`}
+          />
+
+          {/* Open Graph / Facebook */}
+          <meta property="og:type" content="website" />
+          <meta property="og:locale" content={props.locale} />
+          <meta property="og:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="og:title"
+            content={`${t("vc:virtualAssistantTitle")} — ${t("siteTitle")}`}
+          />
+          <meta
+            property="og:description"
+            content={t("vc:virtualAssistantBioBody")}
+          />
+          <meta property="og:image" content={t("metaImage")} />
+          <meta property="og:image:alt" content={t("siteTitle")} />
+
+          {/* Twitter */}
+          <meta property="twitter:card" content="summary_large_image" />
+          <meta property="twitter:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="twitter:title"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
+          <meta name="twitter:creator" content="Service Canada" />
+          <meta
+            property="twitter:description"
+            content={t("vc:virtualAssistantBioBody")}
+          />
+          <meta property="twitter:image" content={t("metaImage")} />
+          <meta property="twitter:image:alt" content={t("siteTitle")} />
+        </Head>
+        <section className="layout-container mb-12">
+          <Heading
+            tabIndex="-1"
+            id="pageMainTitle"
+            title={
+              props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[0].content[0].value
+                : pageData.scFragments[1].scContentFr.json[0].content[0].value
+            }
+          />
+          <div id="postedOnUpdatedOnSection" className="grid grid-cols-12">
+            <p className="col-span-6 sm:col-span-4 lg:col-span-3 font-bold">
+              {props.locale === "en"
+                ? dictionary[9].scTermEn
+                : dictionary[9].scTermFr}
+            </p>
+            <p className="col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5">
+              {pageData.scDateModifiedOverwrite}
+            </p>
+            <p className="row-start-2 col-span-6 sm:col-span-4 lg:col-span-3 font-bold">
+              {props.locale === "en"
+                ? dictionary[4].scTermEn
+                : dictionary[4].scTermFr}
+            </p>
+            <p className="row-start-2 col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5 mt-auto">
+              {pageData.scDateModifiedOverwrite}
+            </p>
+          </div>
+          <div
+            id="mainContentSection"
+            className="grid grid-cols-12 pt-16 gap-x-2"
+          >
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[1].content[0].value
+                : pageData.scFragments[1].scContentFr.json[1].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8 xxl:pt-0">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[2].content[0].value
+                : pageData.scFragments[1].scContentFr.json[2].content[0].value}
+            </p>
+            <div className="hidden lg:grid col-start-9 col-span-4 row-start-1 row-span-2">
+              <div className="flex justify-center">
+                <div className="h-auto max-w-xs">
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[0].scImageEn._publishUrl
+                        : pageData.scFragments[0].scImageFr._publishUrl
+                    }
+                    alt={
+                      props.locale === "en"
+                        ? pageData.scFragments[0].scImageAltTextEn
+                        : pageData.scFragments[0].scImageAltTextFr
+                    }
+                    width={468}
+                    height={462}
+                  />
+                </div>
+              </div>
+            </div>
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[3].content[0].value
+                : pageData.scFragments[1].scContentFr.json[3].content[0].value}
+            </h2>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[4].content[0].value
+                : pageData.scFragments[1].scContentFr.json[4].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[5].content[0].value
+                : pageData.scFragments[1].scContentFr.json[5].content[0].value}
+            </p>
+            <ul className="col-span-12 lg:col-span-8">
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[6].content[0]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[6].content[0]
+                      .content[0].value}
+              </li>
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[6].content[1]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[6].content[1]
+                      .content[0].value}
+              </li>
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[6].content[2]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[6].content[2]
+                      .content[0].value}
+              </li>
+            </ul>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[7].content[0].value
+                : pageData.scFragments[1].scContentFr.json[7].content[0].value}
+            </p>
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[8].content[0].value
+                : pageData.scFragments[1].scContentFr.json[8].content[0].value}
+            </h2>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[9].content[0].value
+                : pageData.scFragments[1].scContentFr.json[9].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[10].content[0].value
+                : pageData.scFragments[1].scContentFr.json[10].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[11].content[0].value
+                : pageData.scFragments[1].scContentFr.json[11].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[12].content[0].value
+                : pageData.scFragments[1].scContentFr.json[12].content[0].value}
+            </p>
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[13].content[0].value
+                : pageData.scFragments[1].scContentFr.json[13].content[0].value}
+            </h2>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[14].content[0].value
+                : pageData.scFragments[1].scContentFr.json[14].content[0].value}
+            </p>
+            <p className="col-span-12 lg:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[15].content[0].value
+                : pageData.scFragments[1].scContentFr.json[15].content[0].value}
+            </p>
+            <ul className="col-span-12 lg:col-span-8">
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[16].content[0]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[16].content[0]
+                      .content[0].value}
+              </li>
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[16].content[1]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[16].content[1]
+                      .content[0].value}
+              </li>
+            </ul>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[17].content[0].value
+                : pageData.scFragments[1].scContentFr.json[17].content[0].value}
+            </p>
+            <ul className="col-span-12 lg:col-span-8">
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[18].content[0]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[18].content[0]
+                      .content[0].value}
+              </li>
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[18].content[1]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[18].content[1]
+                      .content[0].value}
+              </li>
+              <li className="text-[20px]">
+                {props.locale === "en"
+                  ? pageData.scFragments[1].scContentEn.json[18].content[2]
+                      .content[0].value
+                  : pageData.scFragments[1].scContentFr.json[18].content[2]
+                      .content[0].value}
+              </li>
+            </ul>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[19].content[0].value
+                : pageData.scFragments[1].scContentFr.json[19].content[0].value}
+            </p>
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[20].content[0].value
+                : pageData.scFragments[1].scContentFr.json[20].content[0].value}
+            </h2>
+            <p className="col-span-12 lg:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[21].content[0].value
+                : pageData.scFragments[1].scContentFr.json[21].content[0].value}
+            </p>
+            <ActionButton
+              id="feedback-btn"
+              style="secondary"
+              custom="col-span-12 mt-8"
+              href={
+                props.locale === "en"
+                  ? pageData.scFragments[2].scDestinationURLEn
+                  : pageData.scFragments[2].scDestinationURLFr
+              }
+              text={
+                props.locale === "en"
+                  ? pageData.scFragments[2].scTitleEn
+                  : pageData.scFragments[2].scTitleFr
+              }
+              ariaExpanded={props.ariaExpanded}
+            />
+          </div>
+        </section>
+        <CTA
+          heading={
+            props.locale === "en"
+              ? pageData.scFragments[3].scTitleEn
+              : pageData.scFragments[3].scTitleFr
+          }
+          body={
+            props.locale === "en"
+              ? pageData.scFragments[3].scContentEn.json[0].content[0].value
+              : pageData.scFragments[3].scContentFr.json[0].content[0].value
+          }
+          ButtonProps={{
+            id: "cta-btn",
+            text:
+              props.locale === "en"
+                ? pageData.scFragments[3].scLabsButton[0].scTitleEn
+                : pageData.scFragments[3].scLabsButton[0].scTitleFr,
+            href:
+              props.locale === "en"
+                ? pageData.scFragments[3].scLabsButton[0].scDestinationURLEn
+                : pageData.scFragments[3].scLabsButton[0].scDestinationURLFr,
+            className:
+              "w-fit bg-[#26374A] mt-4 text-white visited:text-white hover:bg-[#1C578A] hover:no-underline hover:text-white active:bg-[#16446C]",
+          }}
+          containerClass="layout-container my-4"
+        />
+      </Layout>
+      {props.adobeAnalyticsUrl ? (
+        <script type="text/javascript">_satellite.pageBottom()</script>
+      ) : (
+        ""
+      )}
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  // Get pages data
+  const { data } = await aemServiceInstance.getFragment(
+    "oasBenefitsEstimatorQuery"
+  );
+  // Get paths for dynamic routes from the page name data
+  const paths = getAllUpdateIds(
+    data.scLabsPagev1ByPath.item.scLabProjectUpdates
+  );
+  // Remove characters preceding the page name itself i.e. change "/en/projects/oas-benefits-estimator/what-we-learned" to "what-we-learned"
+  paths.map((path) => {
+    path.locale === "en"
+      ? (path.params.id = path.params.id.slice(36))
+      : (path.params.id = path.params.id.slice(38));
+  });
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export const getStaticProps = async ({ locale, params }) => {
+  // Get pages data
+  const { data } = await aemServiceInstance.getFragment(
+    "oasBenefitsEstimatorQuery"
+  );
+  // get dictionary
+  const { data: dictionary } = await aemServiceInstance.getFragment(
+    "dictionaryQuery"
+  );
+  const pages = data.scLabsPagev1ByPath.item.scLabProjectUpdates;
+  // Return page data that matches the current page being built
+  const pageData = pages.filter((page) => {
+    return (
+      page.scPageNameEn.slice(36) === params.id ||
+      page.scPageNameFr.slice(38) === params.id
+    );
+  });
+  return {
+    props: {
+      locale: locale,
+      pageData: pageData[0],
+      dictionary: dictionary.dictionaryV1List,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      ...(await serverSideTranslations(locale, ["common", "vc"])),
+    },
+  };
+};

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -14,8 +14,6 @@ export default function OASUpdatePage(props) {
   const [dictionary] = useState(props.dictionary.items);
 
   useEffect(() => {
-    console.log(pageData);
-    console.log(dictionary);
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
       window.adobeDataLayer.push({ event: "pageLoad" });
@@ -51,30 +49,40 @@ export default function OASUpdatePage(props) {
           )}
 
           {/* Primary HTML Meta Tags */}
-          <title>{`${
-            props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
-          } — ${t("siteTitle")}`}</title>
-          <meta name="description" content={`${t("vc:metaDescription")}`} />
+          <title>
+            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
+          </title>
+          <meta
+            name="description"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
           <meta name="author" content="Service Canada" />
           <link rel="icon" href="/favicon.ico" />
           <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
-          <meta name="keywords" content={t("vc:keywords")} />
+          <meta
+            name="keywords"
+            content={
+              props.locale === "en"
+                ? pageData.scKeywordsEn
+                : pageData.scKeywordsFr
+            }
+          />
 
           {/* DCMI Meta Tags */}
           <meta
             name="dcterms.title"
-            content={`${t("vc:virtualAssistantTitle")} — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             name="dcterms.language"
             content={props.locale === "en" ? "eng" : "fra"}
             title="ISO639-2/T"
-          />
-          <meta name="dcterms.description" content={t("homeMetaDescription")} />
-          <meta
-            name="dcterms.subject"
-            title="gccore"
-            content={t("metaSubject")}
           />
           <meta name="dcterms.creator" content="Service Canada" />
           <meta name="dcterms.accessRights" content="2" />
@@ -82,45 +90,103 @@ export default function OASUpdatePage(props) {
             name="dcterms.service"
             content="ESDC-EDSC_SCLabs-LaboratoireSC"
           />
-          <meta name="dcterms.modified" title="W3CDTF" content="2022-10-05" />
-          <meta name="dcterms.description" content={t("vc:metaDescription")} />
+          <meta name="dcterms.issued" title="W3CDTF" content="2023-07-07" />
+
+          <meta name="dcterms.modified" title="W3CDTF" content="2023-07-07" />
+          <meta
+            name="dcterms.description"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
           <meta
             name="dcterms.subject"
             title="gccore"
-            content={`${t("vc:metaSubject")}`}
+            content={pageData.scSubject}
           />
+          <meta name="dcterms.spatial" content="Canada" />
 
           {/* Open Graph / Facebook */}
           <meta property="og:type" content="website" />
           <meta property="og:locale" content={props.locale} />
-          <meta property="og:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="og:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
           <meta
             property="og:title"
-            content={`${t("vc:virtualAssistantTitle")} — ${t("siteTitle")}`}
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
           />
           <meta
             property="og:description"
-            content={t("vc:virtualAssistantBioBody")}
+            content={
+              props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[1].content[0].value
+                : pageData.scFragments[1].scContentFr.json[1].content[0].value
+            }
           />
-          <meta property="og:image" content={t("metaImage")} />
-          <meta property="og:image:alt" content={t("siteTitle")} />
+          <meta
+            property="og:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="og:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
 
           {/* Twitter */}
           <meta property="twitter:card" content="summary_large_image" />
-          <meta property="twitter:url" content={t("vc:canonicalURL")} />
+          <meta
+            property="twitter:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
           <meta
             property="twitter:title"
             content={
-              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />
           <meta
             property="twitter:description"
-            content={t("vc:virtualAssistantBioBody")}
+            content={
+              props.locale === "en"
+                ? pageData.scFragments[1].scContentEn.json[1].content[0].value
+                : pageData.scFragments[1].scContentFr.json[1].content[0].value
+            }
           />
-          <meta property="twitter:image" content={t("metaImage")} />
-          <meta property="twitter:image:alt" content={t("siteTitle")} />
+          <meta
+            property="twitter:image"
+            content={pageData.scSocialMediaImageEn._publishUrl}
+          />
+          <meta
+            property="twitter:image:alt"
+            content={
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+            }
+          />
         </Head>
         <section className="layout-container mb-12">
           <Heading

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -133,7 +133,11 @@ export default function OASUpdatePage(props) {
             }
           />
           <div id="postedOnUpdatedOnSection" className="grid grid-cols-12">
-            <p className="col-span-6 sm:col-span-4 lg:col-span-3 font-bold">
+            <p
+              className={`col-span-6 sm:col-span-4 ${
+                props.locale === "en" ? "lg:col-span-2" : "lg:col-span-3"
+              } font-bold`}
+            >
               {props.locale === "en"
                 ? dictionary[9].scTermEn
                 : dictionary[9].scTermFr}
@@ -141,7 +145,11 @@ export default function OASUpdatePage(props) {
             <p className="col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5">
               {pageData.scDateModifiedOverwrite}
             </p>
-            <p className="row-start-2 col-span-6 sm:col-span-4 lg:col-span-3 font-bold">
+            <p
+              className={`row-start-2 col-span-6 sm:col-span-4 ${
+                props.locale === "en" ? "lg:col-span-2" : "lg:col-span-3"
+              } font-bold`}
+            >
               {props.locale === "en"
                 ? dictionary[4].scTermEn
                 : dictionary[4].scTermFr}

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -58,7 +58,6 @@ export default function OasBenefitsEstimator(props) {
   ));
 
   useEffect(() => {
-    console.log(props.dictionary);
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
       window.adobeDataLayer.push({ event: "pageLoad" });

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -7,9 +7,11 @@ import aemServiceInstance from "../../../services/aemServiceInstance";
 import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA } from "@dts-stn/service-canada-design-system";
 import { Heading } from "@dts-stn/service-canada-design-system";
+import Card from "../../../components/molecules/Card";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
+  const [updatesData] = useState(props.updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -30,7 +32,33 @@ export default function OasBenefitsEstimator(props) {
     },
   };
 
+  const displayProjectUpdates = updatesData.map((update) => (
+    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
+      <Card
+        showImage
+        imgSrc={
+          props.locale === "en"
+            ? `https://www.canada.ca${update.scSocialMediaImageEn._path}`
+            : `https://www.canada.ca${update.scSocialMediaImageFr._path}`
+        }
+        imgAlt={
+          props.locale === "en"
+            ? update.scSocialMediaImageAltTextEn
+            : update.scSocialMediaImageAltTextFr
+        }
+        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
+        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
+        description={
+          props.locale === "en"
+            ? props.dictionary.items[9].scTermEn
+            : props.dictionary.items[9].scTermFr
+        }
+      />
+    </li>
+  ));
+
   useEffect(() => {
+    console.log(props.dictionary);
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
       window.adobeDataLayer.push({ event: "pageLoad" });
@@ -320,62 +348,16 @@ export default function OasBenefitsEstimator(props) {
               </div>
             </div>
           </section>
-          <div className="grid grid-cols-12">
-            <h2 className="col-span-12">
+          <div className="grid grid-cols-12 pt-12">
+            <h3 className="col-span-12 text-[20px]">
               {props.locale === "en"
                 ? pageData.scFragments[0].scContentEn.json[5].content[0].value
                 : pageData.scFragments[0].scContentFr.json[5].content[0].value}
-            </h2>
-            <p className="col-span-12 xl:col-span-8">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[6].content[0].value
-                : pageData.scFragments[0].scContentFr.json[6].content[0].value}
-            </p>
-            <p className="col-span-12 xl:col-span-8 pt-6">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[7].content[0].value
-                : pageData.scFragments[0].scContentFr.json[7].content[0].value}
-            </p>
-          </div>
-          <ul className="list-disc list-outside pl-2">
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[0]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[0]
-                      .content[0].value}
-              </p>
-            </li>
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[1]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[1]
-                      .content[0].value}
-              </p>
-            </li>
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[8].content[2]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[8].content[2]
-                      .content[0].value}
-              </p>
-            </li>
-          </ul>
-          <h3 className="my-4 mt-8 text-[20px]">
-            {props.locale === "en"
-              ? pageData.scFragments[0].scContentEn.json[9].content[0].value
-              : pageData.scFragments[0].scContentFr.json[9].content[0].value}
-          </h3>
-          <div className="grid md:flex">
+            </h3>
             <ActionButton
               id="try-btn"
               style="primary"
-              custom="mb-4 md:mb-0 md:mr-8"
+              custom="col-span-12"
               href={
                 props.locale === "en"
                   ? pageData.scFragments[4].scDestinationURLEn
@@ -388,6 +370,33 @@ export default function OasBenefitsEstimator(props) {
               }
               ariaExpanded={props.ariaExpanded}
             />
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[6].content[0].value
+                : pageData.scFragments[0].scContentFr.json[6].content[0].value}
+            </h2>
+            <p className="col-span-12 xl:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[7].content[0].value
+                : pageData.scFragments[0].scContentFr.json[7].content[0].value}
+            </p>
+            <p className="col-span-12 xl:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[8].content[0].value
+                : pageData.scFragments[0].scContentFr.json[8].content[0].value}
+            </p>
+            <p className="col-span-12 xl:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[9].content[0].value
+                : pageData.scFragments[0].scContentFr.json[9].content[0].value}
+            </p>
+          </div>
+          <h3 className="pb-8 pt-10 text-[20px]">
+            {props.locale === "en"
+              ? pageData.scFragments[0].scContentEn.json[10].content[0].value
+              : pageData.scFragments[0].scContentFr.json[10].content[0].value}
+          </h3>
+          <div className="grid md:flex">
             <ActionButton
               id="feedback-btn-2"
               style="secondary"
@@ -404,86 +413,14 @@ export default function OasBenefitsEstimator(props) {
               ariaExpanded={props.ariaExpanded}
             />
           </div>
-          <div className="grid grid-cols-12">
-            <h2 className="col-span-12">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[10].content[0].value
-                : pageData.scFragments[0].scContentFr.json[10].content[0].value}
-            </h2>
-            <p className="col-span-12 xl:col-span-8">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[11].content[0].value
-                : pageData.scFragments[0].scContentFr.json[11].content[0].value}
-            </p>
-          </div>
-          <ul className="list-disc list-outside pl-2">
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[12].content[0]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[12].content[0]
-                      .content[0].value}
-              </p>
-            </li>
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[12].content[1]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[12].content[1]
-                      .content[0].value}
-              </p>
-            </li>
-            <li>
-              <p>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[12].content[2]
-                      .content[0].value
-                  : pageData.scFragments[0].scContentFr.json[12].content[2]
-                      .content[0].value}
-              </p>
-            </li>
+          <h2>
+            {props.locale === "en"
+              ? props.dictionary.items[11].scTermEn
+              : props.dictionary.items[11].scTermFr}
+          </h2>
+          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0">
+            {displayProjectUpdates}
           </ul>
-          <div className="grid grid-cols-12">
-            <p className="col-span-12 xl:col-span-8">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[13].content[0].value
-                : pageData.scFragments[0].scContentFr.json[13].content[0].value}
-            </p>
-            <p className="col-span-12 xl:col-span-8 pt-6">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[14].content[0].value
-                : pageData.scFragments[0].scContentFr.json[14].content[0].value}
-            </p>
-            <h2 className="col-span-12">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[15].content[0].value
-                : pageData.scFragments[0].scContentFr.json[15].content[0].value}
-            </h2>
-            <p className="col-span-12 xl:col-span-8 pb-8">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[16].content[0].value
-                : pageData.scFragments[0].scContentFr.json[16].content[0].value}
-            </p>
-          </div>
-          <div className="md:flex mb-12">
-            <ActionButton
-              id="feedback-btn-2"
-              style="secondary"
-              href={
-                props.locale === "en"
-                  ? pageData.scFragments[5].scDestinationURLEn
-                  : pageData.scFragments[5].scDestinationURLFr
-              }
-              text={
-                props.locale === "en"
-                  ? pageData.scFragments[5].scTitleEn
-                  : pageData.scFragments[5].scTitleFr
-              }
-              ariaExpanded={props.ariaExpanded}
-            />
-          </div>
         </div>
 
         <CTA
@@ -537,6 +474,7 @@ export const getStaticProps = async ({ locale }) => {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
       pageData: pageData.scLabsPagev1ByPath,
+      updatesData: pageData.scLabsPagev1ByPath.item.scLabProjectUpdates,
       dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),
     },

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -48,11 +48,11 @@ export default function OasBenefitsEstimator(props) {
         }
         title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-        description={
+        description={`${
           props.locale === "en"
             ? props.dictionary.items[9].scTermEn
             : props.dictionary.items[9].scTermFr
-        }
+        } ${update.scDateModifiedOverwrite}`}
       />
     </li>
   ));


### PR DESCRIPTION
# OAS Page Design Updates + Blog Page

This PR includes several things:

1. Updates to the OAS overview page design
2. Added new dynamic route `[id].js` under `/pages/projects/oas-benefits-estimator/[id].js` to support the blog posts/updates
3. Hooked up AEM data to new `[id].js` (will want to move to markdown for the majority of the content on these kinds of pages and work on building the client frontend programatically)
4. Updated OAS homepage card to include tag indicating there is a new update (currently hardcoded for OAS, will look into a programatic implementation later)

## Test Instructions

1. Navigate to home page
5. Go to OAS overview
6. See that design matches spec [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=14952-40411&mode=design&t=SKnL4LWuybZYkqCZ-4)
7. Go to the update through the card
8. See that update page design matches spec [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=14948-40097&mode=design&t=SKnL4LWuybZYkqCZ-4)
9. Repeat this for both languages, switch languages mid-navigation

## Definition of Done

- [x] Update CHANGELOG
