### PR TITLE
v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+## Changed
+
+## Fixed
+
+## [v1.8.0] - 2023-07-18
+
+## Added
+
 - Added OAS update page
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-canada-labs",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.15",


### PR DESCRIPTION
# Release PR

## [v1.8.0] - 2023-07-18

## Added

- Added OAS update page

## Changed

- Modified OAS overview page design
- Added update/blog cards to OAS overview page

## Fixed
