### PR TITLE
Moved position of tag element in Card.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Moved tag element in Card.js to the right of the title element
+
 ## Fixed
 
 ## [v1.8.0] - 2023-07-18

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -34,45 +34,49 @@ export const Card = (props) => {
         ) : (
           ""
         )}
-        <p
-          className="block font-display text-lg text-custom-blue-projects-link font-bold underline underline-offset-4 my-1 py-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
-          tabIndex="0"
-        >
-          {props.title}
-          {props.showIcon ? (
-            props.href.substring(0, 8) === "https://" ? (
-              <div className="h-4 w-4 ml-1 mt-1 relative">
-                <img src={props.icon} alt={props.iconAlt} />
-              </div>
+        <div className="flex">
+          <p
+            className="block font-display text-lg text-custom-blue-projects-link font-bold underline underline-offset-4 my-1 py-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
+            tabIndex="0"
+          >
+            {props.title}
+            {props.showIcon ? (
+              props.href.substring(0, 8) === "https://" ? (
+                <div className="h-4 w-4 ml-1 mt-1 relative">
+                  <img src={props.icon} alt={props.iconAlt} />
+                </div>
+              ) : (
+                ""
+              )
             ) : (
               ""
-            )
+            )}
+          </p>
+          {props.showDate ? (
+            <p className="ml-6 text-base text-custom-gray-date">
+              {"Posted: " + props.datePosted.substring(0, 10)}
+            </p>
           ) : (
             ""
           )}
-        </p>
-        {props.showDate ? (
-          <p className="ml-6 text-base text-custom-gray-date">
-            {"Posted: " + props.datePosted.substring(0, 10)}
-          </p>
-        ) : (
-          ""
-        )}
-        {props.showTag ? (
-          <span
-            className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ml-6 ${
-              "border-" +
-              (tagColours[props.tag] || "gray-experiment") +
-              "-darker"
-            } ${
-              "bg-" + (tagColours[props.tag] || "gray-experiment") + "-lighter"
-            }`}
-          >
-            {props.tagLabel}
-          </span>
-        ) : (
-          ""
-        )}
+          {props.showTag ? (
+            <span
+              className={`block w-max py-2 px-2 font-body font-bold border-l-4 mr-6 mt-auto mb-auto ${
+                "border-" +
+                (tagColours[props.tag] || "gray-experiment") +
+                "-darker"
+              } ${
+                "bg-" +
+                (tagColours[props.tag] || "gray-experiment") +
+                "-lighter"
+              }`}
+            >
+              {props.tagLabel}
+            </span>
+          ) : (
+            ""
+          )}
+        </div>
         <p className="text-custom-gray-text mx-6 leading-30px text-lg">
           {props.description}
         </p>

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -52,13 +52,6 @@ export const Card = (props) => {
               ""
             )}
           </p>
-          {props.showDate ? (
-            <p className="ml-6 text-base text-custom-gray-date">
-              {"Posted: " + props.datePosted.substring(0, 10)}
-            </p>
-          ) : (
-            ""
-          )}
           {props.showTag ? (
             <span
               className={`block w-max py-2 px-2 font-body font-bold border-l-4 mr-6 mt-auto mb-auto ${
@@ -77,6 +70,13 @@ export const Card = (props) => {
             ""
           )}
         </div>
+        {props.showDate ? (
+          <p className="ml-6 text-base text-custom-gray-date">
+            {"Posted: " + props.datePosted.substring(0, 10)}
+          </p>
+        ) : (
+          ""
+        )}
         <p className="text-custom-gray-text mx-6 leading-30px text-lg">
           {props.description}
         </p>


### PR DESCRIPTION
# Move position of tag in Card.js

This moves the tag to the right of the card title, per design.

<img width="582" alt="Screenshot 2023-07-18 at 10 59 16 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/682b28fd-8e0b-4020-b766-665c491ba12d">

## Test Instructions

1. Go to homepage
2. See tag is to the right of the OAS card title
3. View on different viewport sizes

## Definition of Done

- [x] Update CHANGELOG
