### PR TITLE
Benefits Navigator Overview Page + Card on Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Benefits Navigator page
+
 ## Changed
 
 - Moved tag element in Card.js to the right of the title element

--- a/graphql/queries/benefitsNavigatorQuery.graphql
+++ b/graphql/queries/benefitsNavigatorQuery.graphql
@@ -1,0 +1,463 @@
+query getBenefitsNavigatorPage {
+  scLabsPagev1ByPath(
+    _path: "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/benefits-navigator/overview"
+  ) {
+    item {
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scLabProjectStage
+      scLabProjectSummaryEn {
+        json
+      }
+      scLabProjectSummaryFr {
+        json
+      }
+      scDescriptionEn {
+        json
+      }
+      scDescriptionFr {
+        json
+      }
+      scLabProjectUpdates {
+        ... on SCLabsPagev1Model {
+          _path
+          scId
+          scPageNameEn
+          scPageNameFr
+          scTitleEn
+          scTitleFr
+          scShortTitleEn
+          scShortTitleFr
+          scBreadcrumbParentPages {
+            ... on SCLabsPagev1Model {
+              scTitleEn
+              scTitleFr
+              scPageNameEn
+              scPageNameFr
+            }
+          }
+          scSubject
+          scKeywordsEn
+          scKeywordsFr
+          scContentType
+          scOwner
+          scDateModifiedOverwrite
+          scAudience
+          scRegion
+          scSocialMediaImageEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scSocialMediaImageFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scSocialMediaImageAltTextEn
+          scSocialMediaImageAltTextFr
+          scNoIndex
+          scNoFollow
+          scFragments {
+            ... on SCLabsContentv1Model {
+              _path
+              scId
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+            }
+            ... on SCLabsImagev1Model {
+              scId
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scImageCaptionEn {
+                json
+              }
+              scImageCaptionFr {
+                json
+              }
+            }
+            ... on SCLabsButtonv1Model {
+              scId
+              scTitleEn
+              scTitleFr
+              scDestinationURLEn
+              scDestinationURLFr
+              scButtonType
+            }
+            ... on SCLabsFeaturev1Model {
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scFragments {
+                ... on SCLabsAlertv1Model {
+                  _path
+                  scId
+                  scTitleEn
+                  scTitleFr
+                  scContentEn {
+                    json
+                  }
+                  scContentFr {
+                    json
+                  }
+                  scAlertType
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scLabsButton {
+                scId
+                scTitleEn
+                scTitleFr
+                scDestinationURLEn
+                scDestinationURLFr
+                scButtonType
+              }
+            }
+            ... on Tooltipv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+            }
+          }
+        }
+      }
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SCLabsContentv1Model {
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scFragments {
+            ... on SCLabsContentv1Model {
+              _path
+              scId
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scFragments {
+                ... on SCLabsImagev1Model {
+                  scId
+                  scImageEn {
+                    ... on ImageRef {
+                      _publishUrl
+                      width
+                      height
+                    }
+                    ... on DocumentRef {
+                      _publishUrl
+                    }
+                  }
+                  scImageFr {
+                    ... on ImageRef {
+                      _publishUrl
+                      width
+                      height
+                    }
+                    ... on DocumentRef {
+                      _publishUrl
+                    }
+                  }
+                  scImageMobileEn {
+                    ... on ImageRef {
+                      _publishUrl
+                      width
+                      height
+                    }
+                    ... on DocumentRef {
+                      _publishUrl
+                    }
+                  }
+                  scImageMobileFr {
+                    ... on ImageRef {
+                      _publishUrl
+                      width
+                      height
+                    }
+                    ... on DocumentRef {
+                      _publishUrl
+                    }
+                  }
+                  scImageAltTextEn
+                  scImageAltTextFr
+                  scImageCaptionEn {
+                    json
+                  }
+                  scImageCaptionFr {
+                    json
+                  }
+                  scLongDescHeadingEn
+                  scLongDescHeadingFr
+                  scLongDescEn {
+                      json
+                  }
+                  scLongDescFr {
+                      json
+                  }
+                }
+              }
+            }
+          }
+        }
+        ... on SCLabsImagev1Model {
+          scId
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
+        }
+        ... on SCLabsButtonv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SCLabsFeaturev1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scFragments {
+            ... on SCLabsAlertv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scAlertType
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
+            scId
+            scTitleEn
+            scTitleFr
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/mscadPageQuery.graphql
+++ b/graphql/queries/mscadPageQuery.graphql
@@ -1,4 +1,4 @@
-query getOASBenefitsEstimatorPage {
+query getMscadPage {
   scLabsPagev1ByPath(
     _path: "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/client-hub/dashboard-overview"
   ) {

--- a/graphql/queries/projectQuery.graphql
+++ b/graphql/queries/projectQuery.graphql
@@ -1,21 +1,16 @@
 query getAllProjects {
-  scLabsPagev1List(filter: {
-    scLabProjectStatus: {
-      _logOp: OR
-      _expressions: [
-          {
-              value: "gc:custom/decd-endc/project-status/past"
-          },
-          {
-              value: "gc:custom/decd-endc/project-status/current"
-          },
-          {
-              value: "gc:custom/decd-endc/project-status/upcoming"
-          },
-
-      ]
+  scLabsPagev1List(
+    filter: {
+      scLabProjectStatus: {
+        _logOp: OR
+        _expressions: [
+          { value: "gc:custom/decd-endc/project-status/past" }
+          { value: "gc:custom/decd-endc/project-status/current" }
+          { value: "gc:custom/decd-endc/project-status/upcoming" }
+        ]
+      }
     }
-  }) {
+  ) {
     items {
       _path
       scId
@@ -24,18 +19,18 @@ query getAllProjects {
       scPageNameEn
       scPageNameFr
       scBreadcrumbParentPages {
-          scTitleEn
-          scTitleFr
-          scPageNameEn
-          scPageNameFr
+        scTitleEn
+        scTitleFr
+        scPageNameEn
+        scPageNameFr
       }
       scShortTitleEn
       scShortTitleFr
       scDescriptionEn {
-          json
+        json
       }
       scDescriptionFr {
-          json
+        json
       }
       scSubject
       scKeywordsEn
@@ -63,14 +58,14 @@ query getAllProjects {
         ... on MultimediaRef {
           _path
           size
-        }          
+        }
       }
       scSocialMediaImageAltTextEn
       scSocialMediaImageAltTextFr
       scNoIndex
       scNoFollow
       scFragments {
-        ... on SCLabsContentModel {
+        ... on SCLabsContentv1Model {
           _path
           scId
           scContentEn {
@@ -80,44 +75,132 @@ query getAllProjects {
             json
           }
         }
-        ... on SCLabsImageModel {
+        ... on SCLabsImagev1Model {
           scId
           scImageEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageAltTextEn
           scImageAltTextFr
-          scImageCaptionEn
-          scImageCaptionFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
+        }
+        ... on SCLabsButtonv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SCLabsFeaturev1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scFragments {
+            ... on SCLabsAlertv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scAlertType
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
+            scId
+            scTitleEn
+            scTitleFr
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
         }
       }
       scLabProjectStatus
@@ -126,10 +209,10 @@ query getAllProjects {
       scDatePaused
       scDateEnded
       scLabProjectSummaryEn {
-          json
+        json
       }
       scLabProjectSummaryFr {
-          json
+        json
       }
     }
   }

--- a/next.config.js
+++ b/next.config.js
@@ -65,6 +65,10 @@ const REWRITES = [
     source: "/projets/tableau-de-bord",
     destination: "/projects/dashboard"
   },
+  {
+    source: "/projets/navigateur-prestations",
+    destination: "/projects/benefits-navigator"
+  }
 ];
 
 securityHeaders = [

--- a/pages/home.js
+++ b/pages/home.js
@@ -14,8 +14,7 @@ export default function Home(props) {
   const currentProjects = experimentsData.filter((project) => {
     return (
       project.scLabProjectStatus[0] ===
-        "gc:custom/decd-endc/project-status/current" &&
-      project.scId !== "BENEFITS-NAVIGATOR-OVERVIEW"
+      "gc:custom/decd-endc/project-status/current"
     );
   });
 
@@ -31,7 +30,12 @@ export default function Home(props) {
         tagLabel={props.locale === "en" ? "New Update" : "Nouvelle mise à jour"}
         tag="current_projects"
         imgSrc={
-          props.locale === "en"
+          // TODO images should always be fetched from the same place in the response data i.e. using the socialMediaImage field
+          project.scId === "BENEFITS-NAVIGATOR-OVERVIEW"
+            ? props.locale === "en"
+              ? `${project.scFragments[0].scImageEn._publishUrl}`
+              : `${project.scFragments[0].scImageFr._publishUrl}`
+            : props.locale === "en"
             ? `https://www.canada.ca${project.scSocialMediaImageEn._path}`
             : `https://www.canada.ca${project.scSocialMediaImageFr._path}`
         }

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -51,6 +51,17 @@ export default function OasBenefitsEstimator(props) {
             {listItems}
           </ul>
         );
+      } else if (item.nodeType === "ordered-list") {
+        const listItems = item.content.map((listItem, index) => (
+          <li key={index} className="my-0">
+            {generateReactElements(listItem.content)}
+          </li>
+        ));
+        elements.push(
+          <ol key={elements.length} className="mb-0 ml-6">
+            {listItems}
+          </ol>
+        );
       } else if (item.nodeType === "list-item") {
         elements.push(
           <li key={elements.length} className="my-0">
@@ -384,7 +395,7 @@ export default function OasBenefitsEstimator(props) {
               </div>
             </div>
           </section>
-          <div className="grid grid-cols-12 pt-12">
+          <div className="grid grid-cols-12">
             <h2 className="col-span-12">
               {props.locale === "en"
                 ? pageData.scFragments[3].scContentEn.json[0].content[0].value
@@ -395,7 +406,7 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[3].scContentEn.json[1].content[0].value
                 : pageData.scFragments[3].scContentFr.json[1].content[0].value}
             </p>
-            <p className="col-span-12 xl:col-span-8 pt-8">
+            <p className="col-span-12 xl:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[3].scContentEn.json[2].content[0].value
                 : pageData.scFragments[3].scContentFr.json[2].content[0].value}
@@ -435,7 +446,7 @@ export default function OasBenefitsEstimator(props) {
                   : pageData.scFragments[4].scContentFr.json[0].content[0]
                       .value}
               </h2>
-              <div id="feature-1" className="grid grid-cols-12 gap-x-6">
+              <div id="feature-1" className="grid grid-cols-12 gap-x-6 mb-9">
                 <div
                   id="image-container"
                   className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
@@ -464,7 +475,7 @@ export default function OasBenefitsEstimator(props) {
                 >
                   <div
                     id="feature-breakdown-content"
-                    className="p-4 border-l-4 border-multi-blue-blue60f"
+                    className="py-4 pl-4 border-l-4 border-multi-blue-blue60f"
                   >
                     <h3 className="mb-2">
                       {props.locale === "en"
@@ -528,7 +539,236 @@ export default function OasBenefitsEstimator(props) {
                   />
                 </div>
               </div>
+              <div id="feature-2" className="grid grid-cols-12 gap-x-6 mb-9">
+                <div
+                  id="image-container"
+                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
+                >
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scImageEn._publishUrl
+                        : pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scImageFr._publishUrl
+                    }
+                    alt={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scImageAltTextEn
+                        : pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scImageAltTextFr
+                    }
+                    className="w-full"
+                  />
+                </div>
+                <div
+                  id="feature-breakdown"
+                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
+                >
+                  <div
+                    id="feature-breakdown-content"
+                    className="p-4 border-l-4 border-multi-blue-blue60f"
+                  >
+                    <h3 className="mb-2">
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scContentEn
+                            .json[0].content[0].value
+                        : pageData.scFragments[4].scFragments[1].scContentFr
+                            .json[0].content[0].value}
+                    </h3>
+                    <p>
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scContentEn
+                            .json[1].content[0].value
+                        : pageData.scFragments[4].scFragments[1].scContentFr
+                            .json[1].content[0].value}
+                    </p>
+                    <ul>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[1].scContentEn
+                              .json[2].content[0].content[0].value
+                          : pageData.scFragments[4].scFragments[1].scContentFr
+                              .json[2].content[0].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[0].scContentEn
+                              .json[2].content[1].content[0].value
+                          : pageData.scFragments[4].scFragments[0].scContentFr
+                              .json[2].content[1].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[1].scContentEn
+                              .json[2].content[2].content[0].value
+                          : pageData.scFragments[4].scFragments[1].scContentFr
+                              .json[2].content[2].content[0].value}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  id="image-text-version"
+                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                >
+                  <Collapse
+                    id="image-text-collapse-1"
+                    title={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scLongDescHeadingEn
+                        : pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scLongDescHeadingFr
+                    }
+                    children={generateReactElements(
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scLongDescEn.json
+                        : pageData.scFragments[4].scFragments[1].scFragments[0]
+                            .scLongDescFr.json
+                    )}
+                  />
+                </div>
+              </div>
+              <div id="feature-3" className="grid grid-cols-12 gap-x-6">
+                <div
+                  id="image-container"
+                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
+                >
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scImageEn._publishUrl
+                        : pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scImageFr._publishUrl
+                    }
+                    alt={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scImageAltTextEn
+                        : pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scImageAltTextFr
+                    }
+                    className="w-full"
+                  />
+                </div>
+                <div
+                  id="feature-breakdown"
+                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
+                >
+                  <div
+                    id="feature-breakdown-content"
+                    className="p-4 border-l-4 border-multi-blue-blue60f"
+                  >
+                    <h3 className="mb-2">
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scContentEn
+                            .json[0].content[0].value
+                        : pageData.scFragments[4].scFragments[2].scContentFr
+                            .json[0].content[0].value}
+                    </h3>
+                    <p>
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scContentEn
+                            .json[1].content[0].value
+                        : pageData.scFragments[4].scFragments[2].scContentFr
+                            .json[1].content[0].value}
+                    </p>
+                    <ul>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[2].scContentEn
+                              .json[2].content[0].content[0].value
+                          : pageData.scFragments[4].scFragments[2].scContentFr
+                              .json[2].content[0].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[2].scContentEn
+                              .json[2].content[1].content[0].value
+                          : pageData.scFragments[4].scFragments[2].scContentFr
+                              .json[2].content[1].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[2].scContentEn
+                              .json[2].content[2].content[0].value
+                          : pageData.scFragments[4].scFragments[2].scContentFr
+                              .json[2].content[2].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[2].scContentEn
+                              .json[2].content[3].content[0].value
+                          : pageData.scFragments[4].scFragments[2].scContentFr
+                              .json[2].content[3].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[2].scContentEn
+                              .json[2].content[4].content[0].value
+                          : pageData.scFragments[4].scFragments[2].scContentFr
+                              .json[2].content[4].content[0].value}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  id="image-text-version"
+                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                >
+                  <Collapse
+                    id="image-text-collapse-1"
+                    title={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scLongDescHeadingEn
+                        : pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scLongDescHeadingFr
+                    }
+                    children={generateReactElements(
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scLongDescEn.json
+                        : pageData.scFragments[4].scFragments[2].scFragments[0]
+                            .scLongDescFr.json
+                    )}
+                  />
+                </div>
+              </div>
             </div>
+            <section
+              id="BENEFITS-NAVIGATOR-HELP-DESIGN"
+              className="grid grid-cols-12 col-span-12"
+            >
+              <h2 className="col-span-12">
+                {props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+                  : pageData.scFragments[5].scContentFr.json[0].content[0]
+                      .value}
+              </h2>
+              <p className="col-span-12 xl:col-span-8">
+                {props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[1].content[0].value
+                  : pageData.scFragments[5].scContentFr.json[1].content[0]
+                      .value}
+              </p>
+              <p className="col-span-12 xl:col-span-8">
+                {props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[2].content[0].value
+                  : pageData.scFragments[5].scContentFr.json[2].content[0]
+                      .value}
+              </p>
+              <p className="col-span-12 xl:col-span-8">
+                {props.locale === "en"
+                  ? pageData.scFragments[5].scContentEn.json[3].content[0].value
+                  : pageData.scFragments[5].scContentFr.json[3].content[0]
+                      .value}
+              </p>
+            </section>
           </div>
           {/* <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0">
             {displayProjectUpdates}

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -1,0 +1,491 @@
+import Head from "next/head";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { Layout } from "../../../components/organisms/Layout";
+import { ActionButton } from "../../../components//atoms/ActionButton";
+import { useEffect, useState } from "react";
+import aemServiceInstance from "../../../services/aemServiceInstance";
+import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
+import { CTA } from "@dts-stn/service-canada-design-system";
+import { Heading } from "@dts-stn/service-canada-design-system";
+import Card from "../../../components/molecules/Card";
+
+export default function OasBenefitsEstimator(props) {
+  const [pageData] = useState(props.pageData.item);
+  const [updatesData] = useState(props.updatesData);
+  const [filteredDictionary] = useState(
+    props.dictionary.items.filter(
+      (item) =>
+        item.scId === "STARTED" ||
+        item.scId === "ENDED" ||
+        item.scId === "PROJECT-STAGE" ||
+        item.scId === "SUMMARY"
+    )
+  );
+  const stageDictionary = {
+    en: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Beta",
+    },
+    fr: {
+      "gc:custom/decd-endc/project-stage/alpha": "Alpha",
+      "gc:custom/decd-endc/project-stage/beta": "Bêta",
+    },
+  };
+
+  const displayProjectUpdates = updatesData.map((update) => (
+    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
+      <Card
+        showImage
+        imgSrc={
+          props.locale === "en"
+            ? `https://www.canada.ca${update.scSocialMediaImageEn._path}`
+            : `https://www.canada.ca${update.scSocialMediaImageFr._path}`
+        }
+        imgAlt={
+          props.locale === "en"
+            ? update.scSocialMediaImageAltTextEn
+            : update.scSocialMediaImageAltTextFr
+        }
+        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
+        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
+        description={`${
+          props.locale === "en"
+            ? props.dictionary.items[9].scTermEn
+            : props.dictionary.items[9].scTermFr
+        } ${update.scDateModifiedOverwrite}`}
+      />
+    </li>
+  ));
+
+  useEffect(() => {
+    if (props.adobeAnalyticsUrl) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
+
+  return (
+    <>
+      <Layout
+        locale={props.locale}
+        langUrl={
+          props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
+        }
+        dateModifiedOverride={pageData.scDateModifiedOverwrite}
+        breadcrumbItems={[
+          {
+            text:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scTitleEn
+                : pageData.scBreadcrumbParentPages[0].scTitleFr,
+            link:
+              props.locale === "en"
+                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
+                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
+          },
+        ]}
+      >
+        <Head>
+          {props.adobeAnalyticsUrl ? (
+            <script src={props.adobeAnalyticsUrl} />
+          ) : (
+            ""
+          )}
+
+          {/* Primary HTML Meta Tags */}
+          <title>
+            {props.locale === "en"
+              ? pageData.scShortTitleEn
+              : pageData.scShortTitleFr}
+          </title>
+          <meta
+            name="description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
+          <meta name="author" content="Service Canada" />
+          <link rel="icon" href="/favicon.ico" />
+          <link
+            rel="canonical"
+            href={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
+          <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+          <meta
+            name="keywords"
+            content={
+              props.locale === "en"
+                ? pageData.scKeywordsEn
+                : pageData.scKeywordsFr
+            }
+          />
+
+          {/* DCMI Meta Tags */}
+          <meta
+            name="dcterms.title"
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
+          />
+          <meta
+            name="dcterms.language"
+            content={props.locale === "en" ? "eng" : "fra"}
+            title="ISO639-2/T"
+          />
+          <meta name="dcterms.creator" content="Service Canada" />
+          <meta name="dcterms.accessRights" content="2" />
+          <meta
+            name="dcterms.service"
+            content="ESDC-EDSC_SCLabs-LaboratoireSC"
+          />
+          <meta name="dcterms.issued" title="W3CDTF" content="2021-07-20" />
+
+          <meta name="dcterms.modified" title="W3CDTF" content="2021-12-16" />
+          <meta
+            name="dcterms.description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
+          <meta
+            name="dcterms.subject"
+            title="gccore"
+            content={pageData.scSubject}
+          />
+          <meta name="dcterms.spatial" content="Canada" />
+
+          {/* Open Graph / Facebook */}
+          <meta property="og:type" content="website" />
+          <meta property="og:locale" content={props.locale} />
+          <meta
+            property="og:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
+          <meta
+            property="og:title"
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
+          />
+          <meta
+            property="og:description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
+          <meta
+            property="og:image"
+            content={pageData.scFragments[0].scImageEn._publishUrl}
+          />
+          <meta
+            property="og:image:alt"
+            content={
+              props.locale === "en"
+                ? pageData.scFragments[0].scImageAltTextEn
+                : pageData.scFragments[0].scImageAltTextFr
+            }
+          />
+
+          {/* Twitter */}
+          <meta property="twitter:card" content="summary_large_image" />
+          <meta
+            property="twitter:url"
+            content={
+              "https://alpha.service.canada.ca" +
+              `${
+                props.locale === "en"
+                  ? pageData.scPageNameEn
+                  : pageData.scPageNameFr
+              }`
+            }
+          />
+          <meta
+            property="twitter:title"
+            content={
+              props.locale === "en"
+                ? pageData.scShortTitleEn
+                : pageData.scShortTitleFr
+            }
+          />
+          <meta name="twitter:creator" content="Service Canada" />
+          <meta
+            property="twitter:description"
+            content={
+              props.locale === "en"
+                ? pageData.scDescriptionEn.json[0].content[0].value
+                : pageData.scDescriptionFr.json[0].content[0].value
+            }
+          />
+          <meta
+            property="twitter:image"
+            content={pageData.scFragments[0].scImageEn._publishUrl}
+          />
+          <meta
+            property="twitter:image:alt"
+            content={
+              props.locale === "en"
+                ? pageData.scFragments[0].scImageAltTextEn
+                : pageData.scFragments[0].scImageAltTextFr
+            }
+          />
+        </Head>
+
+        <div className="layout-container">
+          <section aria-labelledby="pageMainTitle">
+            <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
+              <div className="col-span-2">
+                <Heading
+                  tabIndex="-1"
+                  id="pageMainTitle"
+                  title={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scContentEn.json[0].content[0]
+                          .value
+                      : pageData.scFragments[2].scContentFr.json[0].content[0]
+                          .value
+                  }
+                />
+              </div>
+              <div className="hidden lg:grid row-span-2 row-start-2 col-start-2 p-0 mx-4">
+                <div className="flex justify-center">
+                  <div className="object-fill max-w-350px">
+                    <img
+                      src={
+                        props.locale === "en"
+                          ? pageData.scFragments[0].scImageEn._publishUrl
+                          : pageData.scFragments[0].scImageFr._publishUrl
+                      }
+                      alt={
+                        props.locale === "en"
+                          ? pageData.scFragments[0].scImageAltTextEn
+                          : pageData.scFragments[0].scImageAltTextFr
+                      }
+                      width={468}
+                      height={462}
+                    />
+                  </div>
+                </div>
+              </div>
+              <p className="row-start-2 font-body text-lg mb-4">
+                {props.locale === "en"
+                  ? pageData.scFragments[2].scContentEn.json[1].content[0].value
+                  : pageData.scFragments[2].scContentFr.json[1].content[0]
+                      .value}
+              </p>
+              <div className="row-start-3">
+                <ProjectInfo
+                  termStarted={
+                    props.locale === "en"
+                      ? filteredDictionary[2].scTermEn
+                      : filteredDictionary[2].scTermFr
+                  }
+                  termStage={
+                    props.locale === "en"
+                      ? filteredDictionary[1].scTermEn
+                      : filteredDictionary[1].scTermFr
+                  }
+                  termSummary={
+                    props.locale === "en"
+                      ? filteredDictionary[3].scTermEn
+                      : filteredDictionary[3].scTermFr
+                  }
+                  dateStarted={
+                    pageData.scFragments[2].scContentEn.json[2].content[0].value
+                  }
+                  term={
+                    props.locale === "en"
+                      ? pageData.scFragments[1].scContentEn.json[0].content[0]
+                          .value + " "
+                      : pageData.scFragments[1].scContentFr.json[0].content[0]
+                          .value + " "
+                  }
+                  definition={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scContentEn.json[4].content[0]
+                          .value
+                      : pageData.scFragments[2].scContentFr.json[4].content[0]
+                          .value
+                  }
+                  information={
+                    props.locale === "en"
+                      ? pageData.scFragments[1].scTitleEn
+                      : pageData.scFragments[1].scTitleFr
+                  }
+                  stage={
+                    props.locale === "en"
+                      ? stageDictionary.en[pageData.scLabProjectStage]
+                      : stageDictionary.fr[pageData.scLabProjectStage]
+                  }
+                  summary={
+                    props.locale === "en"
+                      ? pageData.scFragments[2].scContentEn.json[4].content[0]
+                          .value
+                      : pageData.scFragments[2].scContentFr.json[4].content[0]
+                          .value
+                  }
+                />
+              </div>
+            </div>
+          </section>
+          <div className="grid grid-cols-12 pt-12">
+            <h2 className="col-span-12">
+              {props.locale === "en"
+                ? pageData.scFragments[3].scContentEn.json[0].content[0].value
+                : pageData.scFragments[3].scContentFr.json[0].content[0].value}
+            </h2>
+            <p className="col-span-12 xl:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[3].scContentEn.json[1].content[0].value
+                : pageData.scFragments[3].scContentFr.json[1].content[0].value}
+            </p>
+            <p className="col-span-12 xl:col-span-8 pt-8">
+              {props.locale === "en"
+                ? pageData.scFragments[3].scContentEn.json[2].content[0].value
+                : pageData.scFragments[3].scContentFr.json[2].content[0].value}
+            </p>
+            <ul className="col-span-12 xl:col-span-8">
+              <li>
+                {props.locale === "en"
+                  ? pageData.scFragments[3].scContentEn.json[3].content[0]
+                      .content[0].value
+                  : pageData.scFragments[3].scContentFr.json[3].content[0]
+                      .content[0].value}
+              </li>
+              <li>
+                {props.locale === "en"
+                  ? pageData.scFragments[3].scContentEn.json[3].content[1]
+                      .content[0].value
+                  : pageData.scFragments[3].scContentFr.json[3].content[1]
+                      .content[0].value}
+              </li>
+              <li>
+                {props.locale === "en"
+                  ? pageData.scFragments[3].scContentEn.json[3].content[2]
+                      .content[0].value
+                  : pageData.scFragments[3].scContentFr.json[3].content[2]
+                      .content[0].value}
+              </li>
+            </ul>
+            <p className="col-span-12 xl:col-span-8">
+              {props.locale === "en"
+                ? pageData.scFragments[3].scContentEn.json[4].content[0].value
+                : pageData.scFragments[3].scContentFr.json[4].content[0].value}
+            </p>
+            <div id="feature-section" className="grid grid-cols-12 col-span-12">
+              <h2 className="col-span-12">
+                {props.locale === "en"
+                  ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+                  : pageData.scFragments[4].scContentFr.json[0].content[0]
+                      .value}
+              </h2>
+              <div
+                id="image-container"
+                className="object-fill col-span-12 xl:col-span-8"
+              >
+                <img
+                  src={
+                    props.locale === "en"
+                      ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                          .scImageEn._publishUrl
+                      : pageData.scFragments[4].scFragments[0].scFragments[0]
+                          .scImageFr._publishUrl
+                  }
+                  alt={
+                    props.locale === "en"
+                      ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                          .scImageAltTextEn
+                      : pageData.scFragments[4].scFragments[0].scFragments[0]
+                          .scImageAltTextFr
+                  }
+                  className="w-full"
+                />
+              </div>
+            </div>
+          </div>
+          {/* <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0">
+            {displayProjectUpdates}
+          </ul> */}
+        </div>
+
+        {/* <CTA
+          heading={
+            props.locale === "en"
+              ? pageData.scFragments[6].scTitleEn
+              : pageData.scFragments[6].scTitleFr
+          }
+          body={
+            props.locale === "en"
+              ? pageData.scFragments[6].scContentEn.json[0].content[0].value
+              : pageData.scFragments[6].scContentFr.json[0].content[0].value
+          }
+          ButtonProps={{
+            id: "cta-btn",
+            text:
+              props.locale === "en"
+                ? pageData.scFragments[6].scLabsButton[0].scTitleEn
+                : pageData.scFragments[6].scLabsButton[0].scTitleFr,
+            href:
+              props.locale === "en"
+                ? pageData.scFragments[6].scLabsButton[0].scDestinationURLEn
+                : pageData.scFragments[6].scLabsButton[0].scDestinationURLFr,
+            className:
+              "w-fit bg-[#26374A] mt-4 text-white visited:text-white hover:bg-[#1C578A] hover:no-underline hover:text-white active:bg-[#16446C]",
+          }}
+          containerClass="layout-container my-4"
+        /> */}
+      </Layout>
+      {props.adobeAnalyticsUrl ? (
+        <script type="text/javascript">_satellite.pageBottom()</script>
+      ) : (
+        ""
+      )}
+    </>
+  );
+}
+
+export const getStaticProps = async ({ locale }) => {
+  // get page data from AEM
+  const { data: pageData } = await aemServiceInstance.getFragment(
+    "benefitsNavigatorQuery"
+  );
+  // get dictionary
+  const { data: dictionary } = await aemServiceInstance.getFragment(
+    "dictionaryQuery"
+  );
+
+  return {
+    props: {
+      locale: locale,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      pageData: pageData.scLabsPagev1ByPath,
+      updatesData: pageData.scLabsPagev1ByPath.item.scLabProjectUpdates,
+      dictionary: dictionary.dictionaryV1List,
+      ...(await serverSideTranslations(locale, ["common"])),
+    },
+    // revalidate: 10,
+  };
+};

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -42,12 +42,20 @@ export default function OasBenefitsEstimator(props) {
         );
       } else if (item.nodeType === "unordered-list") {
         const listItems = item.content.map((listItem, index) => (
-          <li key={index}>{generateReactElements(listItem.content)}</li>
+          <li key={index} className="my-0">
+            {generateReactElements(listItem.content)}
+          </li>
         ));
-        elements.push(<ul key={elements.length}>{listItems}</ul>);
+        elements.push(
+          <ul key={elements.length} className="mb-0 ml-6">
+            {listItems}
+          </ul>
+        );
       } else if (item.nodeType === "list-item") {
         elements.push(
-          <li key={elements.length}>{generateReactElements(item.content)}</li>
+          <li key={elements.length} className="my-0">
+            {generateReactElements(item.content)}
+          </li>
         );
       } else if (item.nodeType === "text") {
         elements.push(item.value);

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -5,7 +5,7 @@ import { ActionButton } from "../../../components//atoms/ActionButton";
 import { useEffect, useState } from "react";
 import aemServiceInstance from "../../../services/aemServiceInstance";
 import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
-import { CTA } from "@dts-stn/service-canada-design-system";
+import { CTA, Collapse } from "@dts-stn/service-canada-design-system";
 import { Heading } from "@dts-stn/service-canada-design-system";
 import Card from "../../../components/molecules/Card";
 
@@ -31,6 +31,31 @@ export default function OasBenefitsEstimator(props) {
       "gc:custom/decd-endc/project-stage/beta": "Bêta",
     },
   };
+
+  function generateReactElements(json) {
+    const elements = [];
+
+    for (const item of json) {
+      if (item.nodeType === "paragraph") {
+        elements.push(
+          <p key={elements.length}>{generateReactElements(item.content)}</p>
+        );
+      } else if (item.nodeType === "unordered-list") {
+        const listItems = item.content.map((listItem, index) => (
+          <li key={index}>{generateReactElements(listItem.content)}</li>
+        ));
+        elements.push(<ul key={elements.length}>{listItems}</ul>);
+      } else if (item.nodeType === "list-item") {
+        elements.push(
+          <li key={elements.length}>{generateReactElements(item.content)}</li>
+        );
+      } else if (item.nodeType === "text") {
+        elements.push(item.value);
+      }
+    }
+
+    return elements;
+  }
 
   const displayProjectUpdates = updatesData.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
@@ -395,34 +420,105 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[3].scContentEn.json[4].content[0].value
                 : pageData.scFragments[3].scContentFr.json[4].content[0].value}
             </p>
-            <div id="feature-section" className="grid grid-cols-12 col-span-12">
+            <div id="feature-section" className="col-span-12">
               <h2 className="col-span-12">
                 {props.locale === "en"
                   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
                   : pageData.scFragments[4].scContentFr.json[0].content[0]
                       .value}
               </h2>
-              <div
-                id="image-container"
-                className="object-fill col-span-12 xl:col-span-8"
-              >
-                <img
-                  src={
-                    props.locale === "en"
-                      ? pageData.scFragments[4].scFragments[0].scFragments[0]
-                          .scImageEn._publishUrl
-                      : pageData.scFragments[4].scFragments[0].scFragments[0]
-                          .scImageFr._publishUrl
-                  }
-                  alt={
-                    props.locale === "en"
-                      ? pageData.scFragments[4].scFragments[0].scFragments[0]
-                          .scImageAltTextEn
-                      : pageData.scFragments[4].scFragments[0].scFragments[0]
-                          .scImageAltTextFr
-                  }
-                  className="w-full"
-                />
+              <div id="feature-1" className="grid grid-cols-12 gap-x-6">
+                <div
+                  id="image-container"
+                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
+                >
+                  <img
+                    src={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scImageEn._publishUrl
+                        : pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scImageFr._publishUrl
+                    }
+                    alt={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scImageAltTextEn
+                        : pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scImageAltTextFr
+                    }
+                    className="w-full"
+                  />
+                </div>
+                <div
+                  id="feature-breakdown"
+                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
+                >
+                  <div
+                    id="feature-breakdown-content"
+                    className="p-4 border-l-4 border-multi-blue-blue60f"
+                  >
+                    <h3 className="mb-2">
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scContentEn
+                            .json[0].content[0].value
+                        : pageData.scFragments[4].scFragments[0].scContentFr
+                            .json[0].content[0].value}
+                    </h3>
+                    <p>
+                      {props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scContentEn
+                            .json[1].content[0].value
+                        : pageData.scFragments[4].scFragments[0].scContentFr
+                            .json[1].content[0].value}
+                    </p>
+                    <ul>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[0].scContentEn
+                              .json[2].content[0].content[0].value
+                          : pageData.scFragments[4].scFragments[0].scContentFr
+                              .json[2].content[0].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[0].scContentEn
+                              .json[2].content[1].content[0].value
+                          : pageData.scFragments[4].scFragments[0].scContentFr
+                              .json[2].content[1].content[0].value}
+                      </li>
+                      <li>
+                        {props.locale === "en"
+                          ? pageData.scFragments[4].scFragments[0].scContentEn
+                              .json[2].content[2].content[0].value
+                          : pageData.scFragments[4].scFragments[0].scContentFr
+                              .json[2].content[2].content[0].value}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  id="image-text-version"
+                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                >
+                  <Collapse
+                    id="image-text-collapse-1"
+                    title={
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scLongDescHeadingEn
+                        : pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scLongDescHeadingFr
+                    }
+                    children={generateReactElements(
+                      props.locale === "en"
+                        ? pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scLongDescEn.json
+                        : pageData.scFragments[4].scFragments[0].scFragments[0]
+                            .scLongDescFr.json
+                    )}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -342,19 +342,19 @@ export default function MscaDashboard(props) {
                   : pageData.scFragments[3].scContentFr.json[3].content[0]
                       .value}
               </p>
-              <p className="col-span-12 xl:col-span-8 pt-8">
+              <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[4].content[0].value
                   : pageData.scFragments[3].scContentFr.json[4].content[0]
                       .value}
               </p>
-              <p className="col-span-12 xl:col-span-8 pt-8">
+              <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[5].content[0].value
                   : pageData.scFragments[3].scContentFr.json[5].content[0]
                       .value}
               </p>
-              <p className="col-span-12 xl:col-span-8 pt-8">
+              <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[6].content[0].value
                   : pageData.scFragments[3].scContentFr.json[6].content[0]
@@ -372,13 +372,13 @@ export default function MscaDashboard(props) {
                   : pageData.scFragments[3].scContentFr.json[8].content[0]
                       .value}
               </p>
-              <p className="col-span-12 xl:col-span-8 pt-8">
+              <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[9].content[0].value
                   : pageData.scFragments[3].scContentFr.json[9].content[0]
                       .value}
               </p>
-              <p className="col-span-12 xl:col-span-8 pt-8">
+              <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[10].content[0]
                       .value

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -274,21 +274,21 @@ export default function OASUpdatePage(props) {
                 : pageData.scFragments[1].scContentFr.json[5].content[0].value}
             </p>
             <ul className="col-span-12 lg:col-span-8">
-              <li className="text-[20px]">
+              <li>
                 {props.locale === "en"
                   ? pageData.scFragments[1].scContentEn.json[6].content[0]
                       .content[0].value
                   : pageData.scFragments[1].scContentFr.json[6].content[0]
                       .content[0].value}
               </li>
-              <li className="text-[20px]">
+              <li>
                 {props.locale === "en"
                   ? pageData.scFragments[1].scContentEn.json[6].content[1]
                       .content[0].value
                   : pageData.scFragments[1].scContentFr.json[6].content[1]
                       .content[0].value}
               </li>
-              <li className="text-[20px]">
+              <li>
                 {props.locale === "en"
                   ? pageData.scFragments[1].scContentEn.json[6].content[2]
                       .content[0].value

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -208,11 +208,11 @@ export default function OASUpdatePage(props) {
                 ? dictionary[9].scTermEn
                 : dictionary[9].scTermFr}
             </p>
-            <p className="col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5">
+            <p className="col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5 mt-0">
               {pageData.scDateModifiedOverwrite}
             </p>
             <p
-              className={`row-start-2 col-span-6 sm:col-span-4 ${
+              className={`row-start-2 col-span-6 sm:col-span-4 mt-0 ${
                 props.locale === "en" ? "lg:col-span-2" : "lg:col-span-3"
               } font-bold`}
             >
@@ -233,7 +233,7 @@ export default function OASUpdatePage(props) {
                 ? pageData.scFragments[1].scContentEn.json[1].content[0].value
                 : pageData.scFragments[1].scContentFr.json[1].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8 xxl:pt-0">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[2].content[0].value
                 : pageData.scFragments[1].scContentFr.json[2].content[0].value}
@@ -268,7 +268,7 @@ export default function OASUpdatePage(props) {
                 ? pageData.scFragments[1].scContentEn.json[4].content[0].value
                 : pageData.scFragments[1].scContentFr.json[4].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[5].content[0].value
                 : pageData.scFragments[1].scContentFr.json[5].content[0].value}
@@ -311,17 +311,17 @@ export default function OASUpdatePage(props) {
                 ? pageData.scFragments[1].scContentEn.json[9].content[0].value
                 : pageData.scFragments[1].scContentFr.json[9].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[10].content[0].value
                 : pageData.scFragments[1].scContentFr.json[10].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[11].content[0].value
                 : pageData.scFragments[1].scContentFr.json[11].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[12].content[0].value
                 : pageData.scFragments[1].scContentFr.json[12].content[0].value}
@@ -336,7 +336,7 @@ export default function OASUpdatePage(props) {
                 ? pageData.scFragments[1].scContentEn.json[14].content[0].value
                 : pageData.scFragments[1].scContentFr.json[14].content[0].value}
             </p>
-            <p className="col-span-12 lg:col-span-8 pt-8">
+            <p className="col-span-12 lg:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[1].scContentEn.json[15].content[0].value
                 : pageData.scFragments[1].scContentFr.json[15].content[0].value}

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -379,12 +379,12 @@ export default function OasBenefitsEstimator(props) {
                 ? pageData.scFragments[0].scContentEn.json[7].content[0].value
                 : pageData.scFragments[0].scContentFr.json[7].content[0].value}
             </p>
-            <p className="col-span-12 xl:col-span-8 pt-8">
+            <p className="col-span-12 xl:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[0].scContentEn.json[8].content[0].value
                 : pageData.scFragments[0].scContentFr.json[8].content[0].value}
             </p>
-            <p className="col-span-12 xl:col-span-8 pt-8">
+            <p className="col-span-12 xl:col-span-8">
               {props.locale === "en"
                 ? pageData.scFragments[0].scContentEn.json[9].content[0].value
                 : pageData.scFragments[0].scContentFr.json[9].content[0].value}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -295,9 +295,12 @@ html {
   filter: brightness(0) invert(1);
 }
 
-ul,
+ul {
+  @apply ml-4 mb-4;
+}
 li {
   @apply list-disc my-4 ml-4;
+  @apply text-[20px]
 }
 
 .footer-logo {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -296,11 +296,21 @@ html {
 }
 
 ul {
-  @apply ml-4 mb-4;
+  @apply ml-4;
 }
 li {
-  @apply list-disc my-4 ml-4;
+  @apply list-disc ml-4;
   @apply text-[20px]
+}
+ol > li {
+  @apply list-decimal
+}
+
+p + p {
+  margin-top: 2rem;
+}
+ul + p {
+  margin-top: 2rem;
 }
 
 .footer-logo {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -272,6 +272,7 @@ module.exports = {
       },
 
       maxWidth: {
+        "250px": "250px",
         "350px": "350px",
         "450px": "450px",
         "600px": "600px",


### PR DESCRIPTION
# Benefits Navigator Overview Page + Card on Home

This task creates the benefits navigator overview page on the site. English and french paths working with applied rewrite. Please verify it's design and behaviour by checking out the designs [here](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=15727-42759&mode=design&t=QRsJpdg3oyEAARFy-4)

![Screenshot 2023-07-21 at 3 00 44 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/5ebd3f9b-f094-4deb-a35e-a5e594a8ea85)

![Screenshot 2023-07-21 at 2 59 38 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/7c0f33ce-005b-4d4b-a75b-1b75c46a0906)

![Screenshot 2023-07-21 at 3 00 08 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/4dca0dbe-e183-4be6-ad99-f0778728c4ec)


## Test Instructions

1. Go to homepage and see that Benefits Navigator card is available
2. Click the card and navigate to the page
3. See that page matches the [design](https://www.figma.com/file/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?type=design&node-id=15727-42759&mode=design&t=QRsJpdg3oyEAARFy-4)
4. Toggle languages during navigation

## Definition of Done

- [x] Update CHANGELOG
