### PR TITLE
Add missing email to Benefits Navigator page

### DIFF
--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -761,6 +761,12 @@ export default function OasBenefitsEstimator(props) {
                   ? pageData.scFragments[5].scContentEn.json[2].content[0].value
                   : pageData.scFragments[5].scContentFr.json[2].content[0]
                       .value}
+                <a
+                  className="underline underline-offset-4"
+                  href={`mailto:${pageData.scFragments[5].scContentEn.json[2].content[1].value}`}
+                >
+                  {pageData.scFragments[5].scContentEn.json[2].content[1].value}
+                </a>
               </p>
               <p className="col-span-12 xl:col-span-8">
                 {props.locale === "en"


### PR DESCRIPTION
# [Add missing email to Benefits Navigator page](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=133359)

Contact email was missing on the BN page as seen here:

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/76202e6e-9a6b-4272-ac3a-8b04e082f90e)

Email is now on the page:

![Screenshot 2023-07-25 at 7 45 43 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/3a9f2040-45be-4d8c-af42-62cdbc87dfd9)

## Test Instructions

1. Go to BN page and scroll to bottom
2. See that in the second last paragraph the contact email is included and is clickable
