### PR TITLE
Append "- Service Canada Labs" (bilingual) to all active pages

### DIFF
--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -139,8 +139,8 @@ export default function OasBenefitsEstimator(props) {
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
-              ? pageData.scShortTitleEn
-              : pageData.scShortTitleFr}
+              ? `${pageData.scTitleEn} - Service Canada Labs`
+              : `${pageData.scTitleFr} - Laboratoires de Service Canada`}
           </title>
           <meta
             name="description"

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -67,7 +67,9 @@ export default function MscaDashboard(props) {
 
           {/* Primary HTML Meta Tags */}
           <title>
-            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
+            {props.locale === "en"
+              ? `${pageData.scTitleEn} - Service Canada Labs`
+              : `${pageData.scTitleFr} - Laboratoires de Service Canada`}
           </title>
           <meta
             name="description"

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -50,7 +50,9 @@ export default function OASUpdatePage(props) {
 
           {/* Primary HTML Meta Tags */}
           <title>
-            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
+            {props.locale === "en"
+              ? `${pageData.scTitleEn} - Service Canada Labs`
+              : `${pageData.scTitleFr} - Laboratoires de Service Canada`}
           </title>
           <meta
             name="description"

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -95,8 +95,8 @@ export default function OasBenefitsEstimator(props) {
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
-              ? pageData.scShortTitleEn
-              : pageData.scShortTitleFr}
+              ? `${pageData.scTitleEn} - Service Canada Labs`
+              : `${pageData.scTitleFr} - Laboratoires de Service Canada`}
           </title>
           <meta
             name="description"
@@ -417,7 +417,7 @@ export default function OasBenefitsEstimator(props) {
               ? props.dictionary.items[11].scTermEn
               : props.dictionary.items[11].scTermFr}
           </h2>
-          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0">
+          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0 mb-12">
             {displayProjectUpdates}
           </ul>
         </div>


### PR DESCRIPTION
# [Append "- Service Canada Labs" (bilingual) to all active pages](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=133359)

By recommendation from Isabelle Waltzing, we've added "- Service Canada Labs" to the end of page titles on all active pages except the splash page.

## Test Instructions

1. Navigate to all active pages
2. See that they include "- Service Canada Labs"/"- Laboratoires de Service Canada" appended to the page titles
