### PR TITLE
Add OAS Overview page to OAS update page breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Added
 
 - Benefits Navigator page
+- Breadcrumb data for pages is passed through new util function to avoid hardcoding
 
 ## Changed
 

--- a/lib/utils/createBreadcrumbs.js
+++ b/lib/utils/createBreadcrumbs.js
@@ -1,0 +1,12 @@
+export const createBreadcrumbs = (breadcrumbArray, locale) => {
+  return breadcrumbArray.map((breadCrumbItem) => {
+    return {
+      text:
+        locale === "en" ? breadCrumbItem.scTitleEn : breadCrumbItem.scTitleFr,
+      link:
+        locale === "en"
+          ? breadCrumbItem.scPageNameEn
+          : breadCrumbItem.scPageNameFr,
+    };
+  });
+};

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -8,6 +8,7 @@ import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA, Collapse } from "@dts-stn/service-canada-design-system";
 import { Heading } from "@dts-stn/service-canada-design-system";
 import Card from "../../../components/molecules/Card";
+import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -116,18 +117,10 @@ export default function OasBenefitsEstimator(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
-        breadcrumbItems={[
-          {
-            text:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scTitleEn
-                : pageData.scBreadcrumbParentPages[0].scTitleFr,
-            link:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
-                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
-          },
-        ]}
+        breadcrumbItems={createBreadcrumbs(
+          pageData.scBreadcrumbParentPages,
+          props.locale
+        )}
       >
         <Head>
           {props.adobeAnalyticsUrl ? (

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -7,6 +7,7 @@ import aemServiceInstance from "../../../services/aemServiceInstance";
 import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA } from "@dts-stn/service-canada-design-system";
 import { Heading } from "@dts-stn/service-canada-design-system";
+import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 
 export default function MscaDashboard(props) {
   const [pageData] = useState(props.pageData.item);
@@ -45,18 +46,10 @@ export default function MscaDashboard(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
-        breadcrumbItems={[
-          {
-            text:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scTitleEn
-                : pageData.scBreadcrumbParentPages[0].scTitleFr,
-            link:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
-                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
-          },
-        ]}
+        breadcrumbItems={createBreadcrumbs(
+          pageData.scBreadcrumbParentPages,
+          props.locale
+        )}
       >
         <Head>
           {props.adobeAnalyticsUrl ? (

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import aemServiceInstance from "../../../services/aemServiceInstance";
 import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { CTA, Heading } from "@dts-stn/service-canada-design-system";
+import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 
 export default function OASUpdatePage(props) {
   const { t } = useTranslation("common", "vc");
@@ -28,18 +29,10 @@ export default function OASUpdatePage(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
-        breadcrumbItems={[
-          {
-            text:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scTitleEn
-                : pageData.scBreadcrumbParentPages[0].scTitleFr,
-            link:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
-                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
-          },
-        ]}
+        breadcrumbItems={createBreadcrumbs(
+          pageData.scBreadcrumbParentPages,
+          props.locale
+        )}
       >
         <Head>
           {props.adobeAnalyticsUrl ? (

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -8,6 +8,7 @@ import { ProjectInfo } from "../../../components/atoms/ProjectInfo";
 import { CTA } from "@dts-stn/service-canada-design-system";
 import { Heading } from "@dts-stn/service-canada-design-system";
 import Card from "../../../components/molecules/Card";
+import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -72,18 +73,10 @@ export default function OasBenefitsEstimator(props) {
           props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
         }
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
-        breadcrumbItems={[
-          {
-            text:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scTitleEn
-                : pageData.scBreadcrumbParentPages[0].scTitleFr,
-            link:
-              props.locale === "en"
-                ? pageData.scBreadcrumbParentPages[0].scPageNameEn
-                : pageData.scBreadcrumbParentPages[0].scPageNameFr,
-          },
-        ]}
+        breadcrumbItems={createBreadcrumbs(
+          pageData.scBreadcrumbParentPages,
+          props.locale
+        )}
       >
         <Head>
           {props.adobeAnalyticsUrl ? (


### PR DESCRIPTION
# [Add OAS Overview page to OAS update page breadcrumb](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=132796)

The OAS update pages breadcrumb we're missing the link for the OAS Overview page, the direct parent page.

I created a function to loop through the breadcrumb array we get in the data which then puts the data into the array of objects expected by the Layout component. I also added it to all active pages. Works for English and French.

## Test Instructions

1. Go to any project page, see that the breadcrumbs properly render in both languages
2. Go to OAS update page, see that it includes the OAS Overview page in the breadcrumb in both languages

## Definition of Done

- [x] Update CHANGELOG
