### PR TITLE
Set font-size in footer to 14px

### DIFF
--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -23,7 +23,7 @@ export function Footer(props) {
               return (
                 <li
                   key={index}
-                  className="text-white w-64 md:w-56 lg:w-80 my-2.5 hover:underline list-none"
+                  className="text-xs text-white w-64 md:w-56 lg:w-80 my-2.5 hover:underline list-none"
                 >
                   <a className="font-body" href={value.footerBoxlink}>
                     {value.footerBoxLinkText}


### PR DESCRIPTION
# Set font-size in footer to 14px

Default list-item font-size was set to 20px to accommodate the majority of lists that are included in body content. This made the footer list-items also 20px when they should be 14px per the design. This PR fixes this issue by adding a class to the list-items in the footer.

## Test Instructions

1. Go to home page, see that footer font-size is 14px
2. Repeat for other pages
