### PR TITLE
Fix term definition in Benefits Navigator

### DIFF
--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -362,9 +362,9 @@ export default function OasBenefitsEstimator(props) {
                   }
                   definition={
                     props.locale === "en"
-                      ? pageData.scFragments[2].scContentEn.json[4].content[0]
+                      ? pageData.scFragments[1].scContentEn.json[0].content[1]
                           .value
-                      : pageData.scFragments[2].scContentFr.json[4].content[0]
+                      : pageData.scFragments[1].scContentFr.json[0].content[1]
                           .value
                   }
                   information={


### PR DESCRIPTION
# [Fix term definition in Benefits Navigator](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=133660)

Benefits Navigator ProjectInfo component was pulling the wrong data for the "Alpha" definition. This PR corrects that.

## Test Instructions

1. Go to Benefits Navigator page
2. See definition is correct. It should read "Building a draft tool or service and testing it to see if it meets needs."
