### PR TITLE
Collapse component should match image width on Benefits Navigator page

### DIFF
--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -511,7 +511,7 @@ export default function OasBenefitsEstimator(props) {
                 </div>
                 <div
                   id="image-text-version"
-                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
                 >
                   <Collapse
                     id="image-text-collapse-1"
@@ -604,7 +604,7 @@ export default function OasBenefitsEstimator(props) {
                 </div>
                 <div
                   id="image-text-version"
-                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
                 >
                   <Collapse
                     id="image-text-collapse-1"
@@ -711,7 +711,7 @@ export default function OasBenefitsEstimator(props) {
                 </div>
                 <div
                   id="image-text-version"
-                  className="mb-6 col-span-12 row-start-2 xl:row-start-2"
+                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
                 >
                   <Collapse
                     id="image-text-collapse-1"


### PR DESCRIPTION
# [Collapse component on Benefits Navigator page should be the same width as the preceding image](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=133357)

Instead of always spanning the width of the page, the Collapse components on the Benefits Navigator page should match the image size responsiveness.

## Test Instructions

1. Go to Benefits Navigator page
2. See that Collapse components takes up the same width as it's preceding image on small and large displays
