### PR TITLE
Vertical spacing between cards on homepage should be consistent with horizontal spacing

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -19,7 +19,7 @@ export default function Home(props) {
   });
 
   const displayCurrentProjects = currentProjects.map((project) => (
-    <li key={project.scId} className="list-none">
+    <li key={project.scId} className="list-none ml-0">
       <Card
         showImage
         showTag={
@@ -373,7 +373,7 @@ export default function Home(props) {
               }
             />
           </div>
-          <ul className="grid lg:grid-cols-2 gap-x-4 lg:gap-y-12 list-none ml-0">
+          <ul className="grid lg:grid-cols-2 gap-x-4 gap-y-4 list-none ml-0">
             {displayCurrentProjects}
           </ul>
         </section>


### PR DESCRIPTION
# [Make vertical gap on card grid more consistent with horizontal gap](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=133360)

Vertical grid gap on homepage card grid was much larger than that of the horizontal gap. This PR makes the gap the same between the two.

## Test Instructions

1. Go to homepage
2. See that card grid horizontal and vertical spacing match on different display sizes
