### PR TITLE
Prevent site from using dark mode based on user OS-level preference

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,7 @@ module.exports = {
     "border-custom-gray-lighter",
     "border-custom-gray-darker",
   ],
+  darkMode: "class",
   theme: {
     fontFamily: {
       display: ["Lato"],


### PR DESCRIPTION
# [Force light mode on iOS Safari](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=132751)

Spencer had mentioned that when browsing the site with dark mode enabled at the OS-level, the site would apply dark mode. Because we don't have styling to support dark mode, this is unintended. This PR changes the configuration of how our CSS (through tailwind) applies dark mode specifically it will no longer check the "prefers-color-scheme" of the user and must be toggled manually. You can read about it [here](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually).

## Test Instructions

1. Go to homepage
2. Open devtools and then open the settings panel
3. Under preferences force theme to dark
4. Refresh, see that page doesnt change
