### PR TITLE
Increase width of Footer text content to avoid wrapping in french

### DIFF
--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -23,7 +23,7 @@ export function Footer(props) {
               return (
                 <li
                   key={index}
-                  className="text-xs text-white w-64 md:w-56 lg:w-80 my-2.5 hover:underline list-none"
+                  className="text-xs text-white w-64 lg:w-80 my-2.5 hover:underline list-none"
                 >
                   <a className="font-body" href={value.footerBoxlink}>
                     {value.footerBoxLinkText}


### PR DESCRIPTION
# Increase width of Footer text content to avoid wrapping in french

This was an issue noted by Stephanie where footer text when in French would wrap to a second line on smaller displays unnecessarily.

![Screenshot 2023-07-27 at 11 01 34 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/e1126ca3-b6d4-4e89-afd8-8157712da901)

Here it is with the change:

![Screenshot 2023-07-27 at 11 01 47 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/c0dc7201-9207-46c6-a420-a25e575c3b18)

This is a temporary fix until SCDS releases their new Footer component to production.

## Test Instructions

1. Go to homepage
2. Reduce display size to 550px
3. See that french text does not wrap to a second line
