### PR TITLE
Fix incorrect string selection on Benefits Navigator page

### DIFF
--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -587,9 +587,9 @@ export default function OasBenefitsEstimator(props) {
                       </li>
                       <li>
                         {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[0].scContentEn
+                          ? pageData.scFragments[4].scFragments[1].scContentEn
                               .json[2].content[1].content[0].value
-                          : pageData.scFragments[4].scFragments[0].scContentFr
+                          : pageData.scFragments[4].scFragments[1].scContentFr
                               .json[2].content[1].content[0].value}
                       </li>
                       <li>


### PR DESCRIPTION
# [Fix incorrect string selection on Benefits Navigator page](https://dev.azure.com/VP-BD/DECD/_workitems/edit/133668?src=WorkItemMention&src-action=artifact_link)

Fixes incorrect string in second bullet point of second feature breakdown list:

Before:
<img width="1159" alt="Screenshot 2023-08-02 at 10 01 20 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/9fc73390-c468-4c6d-ab56-becaff74c4af">

After:
<img width="1157" alt="Screenshot 2023-08-02 at 10 02 19 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/2d3eec36-4b1c-4eff-9ef0-3c089d996a41">

## Test Instructions

1. Go to Benefits Navigator page
2. See that second feature breakdown section matches second image above

## Definition of Done

Strings should be:

English: "Summaries of the benefits displayed on the same page"

French: "Des résumés de prestations sur la même page"