### PR TITLE
[frontend] fix accessibility issues

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -35,10 +35,7 @@ export const Card = (props) => {
           ""
         )}
         <div className="flex">
-          <p
-            className="block font-display text-lg text-custom-blue-projects-link font-bold underline underline-offset-4 my-1 py-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover"
-            tabIndex="0"
-          >
+          <p className="block font-display text-lg text-custom-blue-projects-link font-bold underline underline-offset-4 my-1 py-2 px-6 items-center group-hover:no-underline group-hover:text-custom-blue-projects-link-hover">
             {props.title}
             {props.showIcon ? (
               props.href.substring(0, 8) === "https://" ? (

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,12 +7,13 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+    const lang = ctx.locale === "default" ? "en" : ctx.locale;
+    return { ...initialProps, lang };
   }
 
   render() {
     return (
-      <Html>
+      <Html lang={this.props.lang === "default" ? "en" : this.props.lang}>
         <Head>
           {/* Import fonts */}
           <link

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,7 @@ export default function Index(props) {
       window.adobeDataLayer = window.adobeDataLayer || [];
       window.adobeDataLayer.push({ event: "pageLoad" });
     }
+    document.documentElement.lang = "en";
   }, []);
 
   return (
@@ -193,11 +194,10 @@ export default function Index(props) {
   );
 }
 
-export const getStaticProps = async ({ locale }) => ({
+export const getServerSideProps = async ({ locale }) => ({
   props: {
-    locale: locale,
-    adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+    locale: locale ?? "en",
+    adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? "",
     ...(await serverSideTranslations(locale, ["common"])),
   },
-  revalidate: 10,
 });

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -440,10 +440,7 @@ export default function OasBenefitsEstimator(props) {
                       .value}
               </h2>
               <div id="feature-1" className="grid grid-cols-12 gap-x-6 mb-9">
-                <div
-                  id="image-container"
-                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
-                >
+                <div className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8">
                   <img
                     src={
                       props.locale === "en"
@@ -462,14 +459,8 @@ export default function OasBenefitsEstimator(props) {
                     className="w-full"
                   />
                 </div>
-                <div
-                  id="feature-breakdown"
-                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
-                >
-                  <div
-                    id="feature-breakdown-content"
-                    className="py-4 pl-4 border-l-4 border-multi-blue-blue60f"
-                  >
+                <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
+                  <div className="py-4 pl-4 border-l-4 border-multi-blue-blue60f">
                     <h3 className="mb-2">
                       {props.locale === "en"
                         ? pageData.scFragments[4].scFragments[0].scContentEn
@@ -509,10 +500,7 @@ export default function OasBenefitsEstimator(props) {
                     </ul>
                   </div>
                 </div>
-                <div
-                  id="image-text-version"
-                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
-                >
+                <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
                   <Collapse
                     id="image-text-collapse-1"
                     title={
@@ -533,10 +521,7 @@ export default function OasBenefitsEstimator(props) {
                 </div>
               </div>
               <div id="feature-2" className="grid grid-cols-12 gap-x-6 mb-9">
-                <div
-                  id="image-container"
-                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
-                >
+                <div className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8">
                   <img
                     src={
                       props.locale === "en"
@@ -555,14 +540,8 @@ export default function OasBenefitsEstimator(props) {
                     className="w-full"
                   />
                 </div>
-                <div
-                  id="feature-breakdown"
-                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
-                >
-                  <div
-                    id="feature-breakdown-content"
-                    className="p-4 border-l-4 border-multi-blue-blue60f"
-                  >
+                <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
+                  <div className="p-4 border-l-4 border-multi-blue-blue60f">
                     <h3 className="mb-2">
                       {props.locale === "en"
                         ? pageData.scFragments[4].scFragments[1].scContentEn
@@ -602,12 +581,9 @@ export default function OasBenefitsEstimator(props) {
                     </ul>
                   </div>
                 </div>
-                <div
-                  id="image-text-version"
-                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
-                >
+                <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
                   <Collapse
-                    id="image-text-collapse-1"
+                    id="image-text-collapse-2"
                     title={
                       props.locale === "en"
                         ? pageData.scFragments[4].scFragments[1].scFragments[0]
@@ -626,10 +602,7 @@ export default function OasBenefitsEstimator(props) {
                 </div>
               </div>
               <div id="feature-3" className="grid grid-cols-12 gap-x-6">
-                <div
-                  id="image-container"
-                  className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8"
-                >
+                <div className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8">
                   <img
                     src={
                       props.locale === "en"
@@ -648,14 +621,8 @@ export default function OasBenefitsEstimator(props) {
                     className="w-full"
                   />
                 </div>
-                <div
-                  id="feature-breakdown"
-                  className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1"
-                >
-                  <div
-                    id="feature-breakdown-content"
-                    className="p-4 border-l-4 border-multi-blue-blue60f"
-                  >
+                <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
+                  <div className="p-4 border-l-4 border-multi-blue-blue60f">
                     <h3 className="mb-2">
                       {props.locale === "en"
                         ? pageData.scFragments[4].scFragments[2].scContentEn
@@ -709,12 +676,9 @@ export default function OasBenefitsEstimator(props) {
                     </ul>
                   </div>
                 </div>
-                <div
-                  id="image-text-version"
-                  className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2"
-                >
+                <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
                   <Collapse
-                    id="image-text-collapse-1"
+                    id="image-text-collapse-3"
                     title={
                       props.locale === "en"
                         ? pageData.scFragments[4].scFragments[2].scFragments[0]

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -240,9 +240,9 @@ export default function MscaDashboard(props) {
                           : pageData.scFragments[1].scImageFr._publishUrl
                       }
                       alt={
-                        props.locale === "en"
+                        (props.locale === "en"
                           ? pageData.scFragments[1].scImageAltTextEn
-                          : pageData.scFragments[1].scImageAltTextFr
+                          : pageData.scFragments[1].scImageAltTextFr) ?? ""
                       }
                       width={468}
                       height={462}

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -43,9 +43,9 @@ export default function OasBenefitsEstimator(props) {
             : `https://www.canada.ca${update.scSocialMediaImageFr._path}`
         }
         imgAlt={
-          props.locale === "en"
+          (props.locale === "en"
             ? update.scSocialMediaImageAltTextEn
-            : update.scSocialMediaImageAltTextFr
+            : update.scSocialMediaImageAltTextFr) ?? ""
         }
         title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
@@ -269,9 +269,9 @@ export default function OasBenefitsEstimator(props) {
                           : pageData.scFragments[1].scImageFr._publishUrl
                       }
                       alt={
-                        props.locale === "en"
+                        (props.locale === "en"
                           ? pageData.scFragments[1].scImageAltTextEn
-                          : pageData.scFragments[1].scImageAltTextFr
+                          : pageData.scFragments[1].scImageAltTextFr) ?? ""
                       }
                       width={468}
                       height={462}
@@ -340,12 +340,12 @@ export default function OasBenefitsEstimator(props) {
               </div>
             </div>
           </section>
-          <div className="grid grid-cols-12 pt-12">
-            <h3 className="col-span-12 text-[20px]">
+          <div className="grid grid-cols-12">
+            <h2 className="col-span-12 text-[20px]">
               {props.locale === "en"
                 ? pageData.scFragments[0].scContentEn.json[5].content[0].value
                 : pageData.scFragments[0].scContentFr.json[5].content[0].value}
-            </h3>
+            </h2>
             <ActionButton
               id="try-btn"
               style="primary"


### PR DESCRIPTION
# [A11y fix](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=128270)

### Changes
- remove duplicate ids
- add empty alt text for decorative images
- modify headings to increase by 1
- remove tabindex on non-interactive components for keyboard accessibility
- remove 'default' locale from next-i18n config.  This isn't a correct locale and has a11y implications when it gets dynamically inserted on the landing page on the html tag.  