### PR TITLE
[frontend] increase fontsize on splash page buttons

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -147,7 +147,7 @@ export default function Index(props) {
                 style="primary"
                 text="English"
                 lang="en"
-                custom="justify-center w-7.5rem xl:w-138px mr-6"
+                custom="justify-center w-7.5rem xl:w-138px mr-6 text-lg"
                 href="/en/home"
               />
               <ActionButton
@@ -156,7 +156,7 @@ export default function Index(props) {
                 text="Français"
                 href="/fr/accueil"
                 lang="fr"
-                custom="justify-center w-7.5rem xl:w-138px"
+                custom="justify-center w-7.5rem xl:w-138px text-lg"
               />
             </div>
           </div>


### PR DESCRIPTION
# [DEV: Splash page buttons are incorrect size](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=98935)

Increase font size on splash page language buttons to match figma designs.

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/b8f9e566-fab3-45bf-94ad-f0dda5be6c5e)

