### PR TITLE
[frontend] add locale prop to ProjectInfo component

### DIFF
--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -258,6 +258,7 @@ export default function MscaDashboard(props) {
               </p>
               <div className="row-start-3">
                 <ProjectInfo
+                  locale={props.locale}
                   termStarted={
                     props.locale === "en"
                       ? filteredDictionary[2].scTermEn

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -287,6 +287,7 @@ export default function OasBenefitsEstimator(props) {
               </p>
               <div className="row-start-3">
                 <ProjectInfo
+                  locale={props.locale}
                   termStarted={
                     props.locale === "en"
                       ? filteredDictionary[2].scTermEn

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -187,6 +187,7 @@ export default function Home(props) {
                       .value}
               </p>
               <ProjectInfo
+                locale={props.locale}
                 termStarted={
                   props.locale === "en"
                     ? filteredDictionary[2].scTermEn


### PR DESCRIPTION
# [Fix issue with OAS project page HelpIcon modal displaying "Fermer" when site is in English](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=136355)

Pass `locale` prop to `ProjectInfo`, otherwise it's undefined and the DS decides to assign the value to 'fr' by default.

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/9e60887b-2e11-4f06-ac6c-04b4934cad0c)

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/af23a2b4-c056-4d40-a74a-fd8fa0da1cf3)
