### PR TITLE
house cleaning the root directory

### DIFF
--- a/__tests__/pages/app.test.js
+++ b/__tests__/pages/app.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from "@testing-library/react";
-import App from "./pages/index";
+import App from "../../pages/index";
 
 describe("App", () => {
   it("renders without crashing", () => {


### PR DESCRIPTION
Move `app.test.js` unit test to the `__test__/pages` folder where it belongs.