### PR TITLE
Change OAS Estimator h3 to h2 for consistent style

### DIFF
--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -384,11 +384,11 @@ export default function OasBenefitsEstimator(props) {
                 : pageData.scFragments[0].scContentFr.json[9].content[0].value}
             </p>
           </div>
-          <h3 className="pb-8 pt-10 text-[20px]">
+          <h2 className="text-[20px]">
             {props.locale === "en"
               ? pageData.scFragments[0].scContentEn.json[10].content[0].value
               : pageData.scFragments[0].scContentFr.json[10].content[0].value}
-          </h3>
+          </h2>
           <div className="grid md:flex">
             <ActionButton
               id="feedback-btn-2"


### PR DESCRIPTION
# [Address spacing issues brought up by Andreanne](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=134471)

## Test Instructions

1. Navigate to OAS page
2. See that margin is consistent for both headings + buttons on the page