### PR TITLE
[fix] Page titles for some pages are not being shown when shared through SMS

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -160,9 +160,7 @@ export default function Home(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta
@@ -200,9 +198,7 @@ export default function Home(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -117,9 +117,7 @@ export default function DynamicBenefitNavigatorPage(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           {/* <meta
@@ -157,9 +155,7 @@ export default function DynamicBenefitNavigatorPage(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -221,9 +221,7 @@ export default function OasBenefitsEstimator(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta
@@ -263,9 +261,7 @@ export default function OasBenefitsEstimator(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -150,9 +150,7 @@ export default function MscaDashboard(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta
@@ -190,9 +188,7 @@ export default function MscaDashboard(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -118,9 +118,7 @@ export default function OASUpdatePage(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta
@@ -158,9 +156,7 @@ export default function OASUpdatePage(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -177,9 +177,7 @@ export default function OasBenefitsEstimator(props) {
           <meta
             property="og:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta
@@ -217,9 +215,7 @@ export default function OasBenefitsEstimator(props) {
           <meta
             property="twitter:title"
             content={
-              props.locale === "en"
-                ? pageData.scShortTitleEn
-                : pageData.scShortTitleFr
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <meta name="twitter:creator" content="Service Canada" />


### PR DESCRIPTION
# [Page titles for some pages are not being shown when shared through SMS](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=137561)

This PR should fix an issue where several pages were not displaying titles when shared through SMS and Twitter. 

## Test Instructions

Will test once merged into dev
