### PR TITLE
[frontend] change new update tag colours

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -12,13 +12,16 @@ export const Card = (props) => {
     current_projects: "custom-green",
     past_projects: "custom-gray",
     upcoming_projects: "custom-blue",
+    new_update: "new-update",
   };
+
+  const tagColour = tagColours[props.tag] ?? "custom-gray";
 
   return (
     <Link href={props.href}>
       <div
         className={`group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
-          "border-" + tagColours[props.tag]
+          "border-" + tagColour
         }`}
         data-testid={props.dataTestId}
         data-cy={props.dataCy}
@@ -51,15 +54,8 @@ export const Card = (props) => {
           </p>
           {props.showTag ? (
             <span
-              className={`block w-max py-2 px-2 font-body font-bold border-l-4 mr-6 mt-auto mb-auto ${
-                "border-" +
-                (tagColours[props.tag] || "gray-experiment") +
-                "-darker"
-              } ${
-                "bg-" +
-                (tagColours[props.tag] || "gray-experiment") +
-                "-lighter"
-              }`}
+              className={`block w-max py-2 px-2 font-body font-bold border-l-4 mr-6 mt-auto mb-auto border-${tagColour}-darker bg-${tagColour}-lighter
+              `}
             >
               {props.tagLabel}
             </span>

--- a/pages/home.js
+++ b/pages/home.js
@@ -28,7 +28,7 @@ export default function Home(props) {
             : false
         }
         tagLabel={props.locale === "en" ? "New update" : "Nouvelle mise à jour"}
-        tag="current_projects"
+        tag="new_update"
         imgSrc={
           // TODO images should always be fetched from the same place in the response data i.e. using the socialMediaImage field
           project.scId === "BENEFITS-NAVIGATOR-OVERVIEW"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,8 @@ module.exports = {
     "border-custom-green-darker",
     "border-custom-gray-lighter",
     "border-custom-gray-darker",
+    "border-new-update-darker",
+    "bg-new-update-lighter",
   ],
   darkMode: "class",
   theme: {
@@ -165,6 +167,10 @@ module.exports = {
           purple: {
             purple50: "#7834BC",
           },
+        },
+        "new-update": {
+          darker: "#269ABC",
+          lighter: "#D7FAFF",
         },
         "custom-blue": {
           blue: "#1D5B90",


### PR DESCRIPTION
[Update tag colour for "New updates" on project cards to align with GOC design system](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=136341)

Tag colour changed to match design system and Figma. See below:

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/8cf57891-949b-4cc7-a430-1794dd09b5dd)