### PR TITLE
[fix] Query for article pages directly instead of as a property of the parent project page

### DIFF
--- a/graphql/queries/benefitsNavigatorArticlesQuery.graphql
+++ b/graphql/queries/benefitsNavigatorArticlesQuery.graphql
@@ -1,14 +1,6 @@
 query getBenefitsNavigatorArticles {
   scLabsPagev1List(
     filter: {
-      scContentType: {
-        _expressions: [
-          {
-            value: "gc:content-types/promotional-material-featured-articles"
-            _operator: EQUALS
-          }
-        ]
-      }
       _path: {
         _expressions: [
           {

--- a/graphql/queries/benefitsNavigatorArticlesQuery.graphql
+++ b/graphql/queries/benefitsNavigatorArticlesQuery.graphql
@@ -1,0 +1,208 @@
+query getBenefitsNavigatorArticles {
+  scLabsPagev1List(
+    filter: {
+      scContentType: {
+        _expressions: [
+          {
+            value: "gc:content-types/promotional-material-featured-articles"
+            _operator: EQUALS
+          }
+        ]
+      }
+      _path: {
+        _expressions: [
+          {
+            value: "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/benefits-navigator/updates/"
+            _operator: STARTS_WITH
+          }
+        ]
+      }
+    }
+  ) {
+    items {
+      _path
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SCLabsContentv1Model {
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+        ... on SCLabsImagev1Model {
+          scId
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
+        }
+        ... on SCLabsButtonv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SCLabsFeaturev1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scFragments {
+            ... on SCLabsAlertv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scAlertType
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
+            scId
+            scTitleEn
+            scTitleFr
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/queries/benefitsNavigatorArticlesQuery.graphql
+++ b/graphql/queries/benefitsNavigatorArticlesQuery.graphql
@@ -1,6 +1,14 @@
 query getBenefitsNavigatorArticles {
   scLabsPagev1List(
     filter: {
+      scContentType: {
+        _expressions: [
+          {
+            value: "gc:content-types/promotional-material-featured-articles"
+            _operator: EQUALS
+          }
+        ]
+      }
       _path: {
         _expressions: [
           {

--- a/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
@@ -1,6 +1,14 @@
 query getOASBenefitsEstimatorArticles {
   scLabsPagev1List(
     filter: {
+      scContentType: {
+        _expressions: [
+          {
+            value: "gc:content-types/promotional-material-featured-articles"
+            _operator: EQUALS
+          }
+        ]
+      }
       _path: {
         _expressions: [
           {

--- a/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
@@ -1,14 +1,6 @@
 query getOASBenefitsEstimatorArticles {
   scLabsPagev1List(
     filter: {
-      scContentType: {
-        _expressions: [
-          {
-            value: "gc:content-types/promotional-material-featured-articles"
-            _operator: EQUALS
-          }
-        ]
-      }
       _path: {
         _expressions: [
           {

--- a/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
+++ b/graphql/queries/oasBenefitsEstimatorArticlesQuery.graphql
@@ -1,0 +1,208 @@
+query getOASBenefitsEstimatorArticles {
+  scLabsPagev1List(
+    filter: {
+      scContentType: {
+        _expressions: [
+          {
+            value: "gc:content-types/promotional-material-featured-articles"
+            _operator: EQUALS
+          }
+        ]
+      }
+      _path: {
+        _expressions: [
+          {
+            value: "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/"
+            _operator: STARTS_WITH
+          }
+        ]
+      }
+    }
+  ) {
+    items {
+      _path
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scBreadcrumbParentPages {
+        ... on SCLabsPagev1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SCLabsContentv1Model {
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+        ... on SCLabsImagev1Model {
+          scId
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
+        }
+        ... on SCLabsButtonv1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SCLabsFeaturev1Model {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scFragments {
+            ... on SCLabsAlertv1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scAlertType
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
+            scId
+            scTitleEn
+            scTitleFr
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
+        }
+        ... on Tooltipv1Model {
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -417,12 +417,10 @@ export default function DynamicBenefitNavigatorPage(props) {
 export async function getStaticPaths() {
   // Get pages data
   const { data } = await aemServiceInstance.getFragment(
-    "benefitsNavigatorQuery"
+    "benefitsNavigatorArticlesQuery"
   );
   // Get paths for dynamic routes from the page name data
-  const paths = getAllUpdateIds(
-    data.scLabsPagev1ByPath.item.scLabProjectUpdates
-  );
+  const paths = getAllUpdateIds(data.scLabsPagev1List.items);
   paths.map((path) => {
     path.locale === "en"
       ? (path.params.id = path.params.id.slice(32))
@@ -437,13 +435,13 @@ export async function getStaticPaths() {
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
   const { data } = await aemServiceInstance.getFragment(
-    "benefitsNavigatorQuery"
+    "benefitsNavigatorArticlesQuery"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.scLabsPagev1ByPath.item.scLabProjectUpdates;
+  const pages = data.scLabsPagev1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -448,12 +448,10 @@ export default function OASUpdatePage(props) {
 export async function getStaticPaths() {
   // Get pages data
   const { data } = await aemServiceInstance.getFragment(
-    "oasBenefitsEstimatorQuery"
+    "oasBenefitsEstimatorArticlesQuery"
   );
   // Get paths for dynamic routes from the page name data
-  const paths = getAllUpdateIds(
-    data.scLabsPagev1ByPath.item.scLabProjectUpdates
-  );
+  const paths = getAllUpdateIds(data.scLabsPagev1List.items);
   // Remove characters preceding the page name itself i.e. change "/en/projects/oas-benefits-estimator/what-we-learned" to "what-we-learned"
   paths.map((path) => {
     path.locale === "en"
@@ -469,13 +467,13 @@ export async function getStaticPaths() {
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
   const { data } = await aemServiceInstance.getFragment(
-    "oasBenefitsEstimatorQuery"
+    "oasBenefitsEstimatorArticlesQuery"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.scLabsPagev1ByPath.item.scLabProjectUpdates;
+  const pages = data.scLabsPagev1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (


### PR DESCRIPTION
# [Query for update pages directly (instead of as a property of the parent project page) to fix issue with article pages not showing breadcrumbs for project pages](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=135491)

This fixes an issue where breadcrumbs on article pages were not displaying the link to the preceding project page. This arose from an issue with AEM queries where, when querying for article pages as an associated property of the project page, the breadcrumbs for that associated article would unfortunately not include the breadcrumb of the parent project page. To fix this, I replaced the queries on the dynamic pages to query for their respective articles "directly".

## Test Instructions

1. Navigate to either OAS or BN article pages
2. See that breadcrumb includes the preceding project page
