### PR TITLE
add svg chevron icon to breadcrumb

### DIFF
--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -1,5 +1,7 @@
 import PropTypes from "prop-types";
 import Link from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
 /**
  *  Breadcrumb component
@@ -24,7 +26,12 @@ export function Breadcrumb(props) {
                   key={key}
                   className="inline-block min-w-0 max-w-full truncate -my-4 px-1"
                 >
-                  <span className="inline-block align-middle text-gray-breadcrumb icon-cheveron-right mr-4" />
+                  <span className="inline-block mr-4">
+                    <FontAwesomeIcon
+                      icon={faChevronRight}
+                      className="text-xs text-gray-breadcrumb"
+                    />
+                  </span>
                   <Link
                     href={item.link}
                     className="text-sm hover:text-canada-footer-hover-font-blue text-canada-footer-font visited:text-purple-700 underline"


### PR DESCRIPTION
# [Chevron icon for breadcrumbs is not appearing in local dev](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=138367)

I introduced this bug by removing icomoon.  Totally my fault.  Here's a fix that instead uses fontawesome 
(we're already depending on this elsewhere in the project) in the breadcrumb component:

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/50d89132-17c5-4656-b6fd-5450f1655ed5)
