### PR TITLE
[fix] Revert invalid style-src property "nonce" to "self"

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,7 +69,7 @@ securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: `default-src 'self' dts-stn.com *.dts-stn.com *.adobe.com https://assets.adobedtm.com *.omniture.com *.2o7.net; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; connect-src 'self' *.adobe.com https://assets.adobedtm.com *.demdex.net *.omtrdc.net cm.everesttech.net; style-src 'nonce' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' data: *.omtrdc.net *.demdex.net cm.everesttech.net https://assets.adobedtm.com https://www.canada.ca; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com data:; frame-src 'self' *.adobe.com https://assets.adobedtm.com *.demdex.net; script-src 'self' 'unsafe-inline' *.adobe.com *.omniture.com *.2o7.net https://*.demdex.net https://cm.everesttech.net ${
+    value: `default-src 'self' dts-stn.com *.dts-stn.com *.adobe.com https://assets.adobedtm.com *.omniture.com *.2o7.net; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; connect-src 'self' *.adobe.com https://assets.adobedtm.com *.demdex.net *.omtrdc.net cm.everesttech.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' data: *.omtrdc.net *.demdex.net cm.everesttech.net https://assets.adobedtm.com https://www.canada.ca; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com data:; frame-src 'self' *.adobe.com https://assets.adobedtm.com *.demdex.net; script-src 'self' 'unsafe-inline' *.adobe.com *.omniture.com *.2o7.net https://*.demdex.net https://cm.everesttech.net ${
       process.env.CI === "true"
         ? "'unsafe-eval'"
         : process.env.NODE_ENV === "development"


### PR DESCRIPTION
# [Fix issue with styles not loading in dev environment due to CSP config](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=140501)

If you navigate to our dev environment at https://alphasite-appservice-dev.azurewebsites.net/, you can see that the styles are not loading and we receive the following error:

![Screenshot 2023-09-11 at 2 12 07 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/f1bb18c1-58be-4e5a-9c17-a22ad19ff078)

This PR should fix the issue. Will test as soon as it's deployed to the dev environment.
