### PR TITLE
[fix] make card height 100%

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -20,7 +20,7 @@ export const Card = (props) => {
   return (
     <Link href={props.href}>
       <div
-        className={`group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
+        className={`h-full group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
           "border-" + tagColour
         }`}
         data-testid={props.dataTestId}

--- a/pages/home.js
+++ b/pages/home.js
@@ -374,7 +374,7 @@ export default function Home(props) {
               }
             />
           </div>
-          <ul className="grid lg:grid-cols-2 gap-x-4 gap-y-4 list-none ml-0">
+          <ul className="grid lg:grid-cols-2 gap-4 list-none ml-0">
             {displayCurrentProjects}
           </ul>
         </section>


### PR DESCRIPTION
# [Adjust card style for SCCH dashboard](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)

Ensure cards occupy 100% of the available height of their grid container.  Fixes the below issue:

![image](https://github.com/DTS-STN/Service-Canada-Labs/assets/48450599/fbed3816-7d55-45dd-ba3d-a246ae929eaa)
