### PR TITLE
remove oas ee new tag and update logic for displaying tag

### DIFF
--- a/graphql/queries/projectQuery.graphql
+++ b/graphql/queries/projectQuery.graphql
@@ -18,6 +18,7 @@ query getAllProjects {
       scTitleFr
       scPageNameEn
       scPageNameFr
+      scLabsNewExpiryDate
       scBreadcrumbParentPages {
         scTitleEn
         scTitleFr

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,15 +1,15 @@
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Layout } from "../components/organisms/Layout";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import Card from "../components/molecules/Card";
 import aemServiceInstance from "../services/aemServiceInstance";
 import { Heading } from "../components/design-system/Heading";
 import { ContextualAlert } from "../components/design-system/ContextualAlert";
 
 export default function Home(props) {
-  const [pageData] = useState(props.pageData.item);
-  const [experimentsData] = useState(props.experimentsData);
+  const pageData = props.pageData?.item;
+  const experimentsData = props.experimentsData;
 
   const currentProjects = experimentsData.filter((project) => {
     return (
@@ -23,9 +23,8 @@ export default function Home(props) {
       <Card
         showImage
         showTag={
-          project.scTitleEn === "Old Age Security Benefits Estimator"
-            ? true
-            : false
+          project.scLabsNewExpiryDate &&
+          Date.now() <= new Date(project.scLabsNewExpiryDate)
         }
         tagLabel={props.locale === "en" ? "New update" : "Nouvelle mise à jour"}
         tag="new_update"


### PR DESCRIPTION
# [Implement "New update" tag guidance to the home page](https://dev.azure.com/VP-BD/DECD/_workitems/edit/140804)

The content chapter, design team, and devs have agreed that the approach to take with regards to displaying the "New Update" tag on project cards is to have a field in AEM named `scLabNewExpiryDate`.  This is the date (not inclusive) at which the new tag should *not* be displayed on project cards on the home page.  

### Changes
- update gql query to pull in the `scLabsNewExpiryDate` on the project query
- add conditional to only render the tag if the current datetime is less than or equal to the expiry date in AEM.