### PR TITLE
Remove h2 top margin from RAP component

### DIFF
--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -125,7 +125,7 @@ export function ReportAProblem(props) {
         ""
       ) : (
         <>
-          <h2 className="text-base font-body">
+          <h2 className="text-base font-body mt-0">
             {t("reportAProblemTitle", { lng: props.language })}
           </h2>
           <ul className="list-outside list-disc px-6 py-2">


### PR DESCRIPTION
# [Remove h2 top margin from RAP component](https://dev.azure.com/VP-BD/DECD/_workitems/edit/144361)

Small fix to override h2 default top-margin

**Before**
<img width="469" alt="Screenshot 2023-10-10 at 12 46 23 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/dd2b9021-5f56-4cd3-8282-656d56967972">

**After**
<img width="481" alt="Screenshot 2023-10-10 at 12 45 49 PM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/a1037258-fee6-46d3-809e-a7e18d5eada2">

## Test Instructions

1. Navigate to any page
2. See no top margin on RAP h2
