### PR TITLE
Ignore unneccesary yarn files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,12 @@ terraform.rc
 .idea
 
 graphql/.cache/
+
+# Ignore yarn related files
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Small change to the .gitignore to stop tracking yarn files that do not need to be tracked
