### PR TITLE
[fix] Click area in breadcrumbs not aligned to element 

### DIFF
--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -9,8 +9,8 @@ import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 export function Breadcrumb(props) {
   return (
     <nav aria-label="breadcrumbs">
-      <ul className="block text-custom-blue-dark text-base font-body -ml-4 -my-4 ">
-        <li className="inline-block min-w-0 max-w-full truncate px-1 -my-4">
+      <ul className="block text-custom-blue-dark text-base font-body">
+        <li className="inline-block min-w-0 max-w-full truncate px-1 ml-0">
           <Link
             href="https://www.canada.ca/"
             className="text-sm hover:text-custom-blue-link visited:text-purple-700 underline"
@@ -24,9 +24,9 @@ export function Breadcrumb(props) {
               return (
                 <li
                   key={key}
-                  className="inline-block min-w-0 max-w-full truncate -my-4 px-1"
+                  className="inline-block min-w-0 max-w-full truncate px-1 ml-4"
                 >
-                  <span className="inline-block mr-4">
+                  <span className="inline-block mr-6">
                     <FontAwesomeIcon
                       icon={faChevronRight}
                       className="text-xs text-gray-breadcrumb"

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -102,7 +102,7 @@ export const Layout = ({
           </div>
         </div>
 
-        <div className="layout-container mt-20">
+        <div className="layout-container mt-4 lg:mt-20">
           <Breadcrumb items={breadcrumbItems} />
         </div>
       </header>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -59,7 +59,7 @@ export const Layout = ({
         ) : (
           ""
         )}
-        <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between  mt-2">
+        <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between mt-2">
           <div
             className="flex flex-row justify-between items-center lg:mt-7 mt-1.5"
             role="navigation"
@@ -102,10 +102,8 @@ export const Layout = ({
           </div>
         </div>
 
-        <div className="border-t pb-2 mt-4">
-          <div className="layout-container mt-10 mb-2">
-            <Breadcrumb items={breadcrumbItems} />
-          </div>
+        <div className="layout-container mt-20">
+          <Breadcrumb items={breadcrumbItems} />
         </div>
       </header>
 


### PR DESCRIPTION
# [Click area in breadcrumb links are not aligned with the element itself](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)

Due to negative margins, the click area of breadcrumb links was not aligned with the link element and consequently clicking on the link would do nothing when clicking certain areas of the link element. 

This PR also includes a small change to the layout where the border between the GOC heading image and the breadcrumbs was removed to align with the current design in figma.

Desktop before:

<img width="841" alt="Screenshot 2023-11-15 at 11 42 35 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/cf432367-a555-4643-8ffa-006957d23467">

Desktop after:

<img width="786" alt="Screenshot 2023-11-15 at 11 41 17 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/87599d6f-8fb3-40a8-9fcb-cdda12afb6e9">

Mobile before:

<img width="464" alt="Screenshot 2023-11-15 at 11 42 55 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/0188ac09-deda-4ace-966b-969842757748">

Mobile after:

<img width="495" alt="Screenshot 2023-11-15 at 11 45 13 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/48142772-ee3a-48a3-9972-be03bf718eee">


## Test Instructions

1. Navigate to an article page
2. Hover over breadcrumbs or use devtools to see clickarea
3. See that the whole link element is clickable
