### PR TITLE
Set node version to 18.x in Github workflows

### DIFF
--- a/.github/workflows/build-and-deploy-storybooks.yml
+++ b/.github/workflows/build-and-deploy-storybooks.yml
@@ -8,9 +8,18 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [18.x]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install 🔧 # This example project is built using yarn and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: yarn install

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -8,9 +8,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [18.x]
     steps:
       - name: Checkout 🔔
         uses: actions/checkout@v2.3.1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install 🔧
         run: yarn install


### PR DESCRIPTION
This PR sets the node version in our github workflow actions to at least version 18. Reason to do this is that Github actions use Node v16 by default, but because we are using Yarn v4, we want to ensure yarn installs are running in an environment using at minimum Node v18.
