### PR TITLE
Use scTitle field for main heading and page title

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -81,9 +81,7 @@ export default function Home(props) {
 
           {/* Primary HTML Meta Tags */}
           <title>
-            {props.locale === "en"
-              ? pageData.scShortTitleEn
-              : pageData.scShortTitleFr}
+            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
           </title>
           <meta
             name="description"
@@ -233,10 +231,8 @@ export default function Home(props) {
                 id="pageMainTitle"
                 title={
                   props.locale === "en"
-                    ? pageData.scFragments[0].scContentEn.json[0].content[0]
-                        .value
-                    : pageData.scFragments[0].scContentFr.json[0].content[0]
-                        .value
+                    ? pageData.scTitleEn
+                    : pageData.scTitleFr
                 }
               />
             </div>

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -300,10 +300,8 @@ export default function BenefitsNavigatorOverview(props) {
                   id="pageMainTitle"
                   title={
                     props.locale === "en"
-                      ? pageData.scFragments[2].scContentEn.json[0].content[0]
-                          .value
-                      : pageData.scFragments[2].scContentFr.json[0].content[0]
-                          .value
+                      ? pageData.scTitleEn
+                      : pageData.scTitleFr
                   }
                 />
               </div>

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -191,9 +191,7 @@ export default function OASUpdatePage(props) {
             tabIndex="-1"
             id="pageMainTitle"
             title={
-              props.locale === "en"
-                ? pageData.scFragments[1].scContentEn.json[0].content[0].value
-                : pageData.scFragments[1].scContentFr.json[0].content[0].value
+              props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
             }
           />
           <div id="postedOnUpdatedOnSection" className="grid grid-cols-12">

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -253,10 +253,8 @@ export default function OasBenefitsEstimator(props) {
                   id="pageMainTitle"
                   title={
                     props.locale === "en"
-                      ? pageData.scFragments[0].scContentEn.json[0].content[0]
-                          .value
-                      : pageData.scFragments[0].scContentFr.json[0].content[0]
-                          .value
+                      ? pageData.scTitleEn
+                      : pageData.scTitleFr
                   }
                 />
               </div>


### PR DESCRIPTION
# [Modify pages to use scTitle field for main heading and page title](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)

Small change to use scTitleEn/Fr for main heading and page titles where they weren't already being used

## Test Instructions

1. See that relevant pages main heading and page title render properly
