### PR TITLE
fix rewrite for french article paths under DS Playbook

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,10 @@ const REWRITES = [
     source: "/projets/guide-normes-numeriques",
     destination: "/projects/digital-standards-playbook",
   },
+  {
+    source: "/projets/guide-normes-numeriques/:slug",
+    destination: "/projects/digital-standards-playbook/:slug",
+  },
 ];
 
 securityHeaders = [

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -477,8 +477,6 @@ export const getStaticProps = async ({ locale }) => {
     "dictionaryQuery"
   );
 
-  console.log(updatesData.sclabsPageV1List.items);
-
   return {
     props: {
       locale: locale,


### PR DESCRIPTION
Add missing rewrite to support routing to french URLs for DS Playbook articles
