### PR TITLE
Add Image component to FragmentRender

### DIFF
--- a/components/fragment_renderer/FragmentRender.js
+++ b/components/fragment_renderer/FragmentRender.js
@@ -4,6 +4,7 @@ import TextContent from "./fragment_components/TextContent";
 import Button from "./fragment_components/Button";
 import ArticleCTA from "./fragment_components/ArticleCTA";
 import QuoteVerticalLineContent from "./fragment_components/QuoteVerticalLineContent";
+import Image from "./fragment_components/Image";
 
 const FRAGMENTS = {
   "SCLabs-Comp-Content-Image-v1": TextWithImage,
@@ -11,6 +12,7 @@ const FRAGMENTS = {
   "SCLabs-Content-v1": TextContent,
   "SCLabs-Button-v1": Button,
   "SCLabs-Feature-v1": ArticleCTA,
+  "SCLabs-Image-v1": Image,
 };
 
 export default function FragmentRender(props) {

--- a/components/fragment_renderer/fragment_components/Image.js
+++ b/components/fragment_renderer/fragment_components/Image.js
@@ -1,0 +1,25 @@
+export default function Image(props) {
+  return (
+    <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
+      <img
+        id={props.scId}
+        src={
+          props.locale === "en"
+            ? props.fragmentData.scImageEn._publishUrl
+            : props.fragmentData.scImageFr._publishUrl
+        }
+        alt={
+          props.locale === "en"
+            ? props.fragmentData.scImageAltTextEn
+            : props.fragmentData.scImageAltTextFr
+        }
+        className="col-span-12 lg:col-span-10"
+      />
+      <p className="grid row-start-2 col-span-12 lg:col-span-10 justify-around">
+        {props.locale === "en"
+          ? props.fragmentData.scImageCaptionEn.json[0].content[0].value
+          : props.fragmentData.scImageCaptionFr.json[0].content[0].value}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR includes an the addition of an Image component to the FragmentRender to support images in articles.

## Test Instructions

1. Navigate to DS Playbook project page
2. Go to article
3. See that image "Figure 1" renders
