### PR TITLE
move analytics scripts to _document.js

### DIFF
--- a/components/fragment_renderer/PageHead.js
+++ b/components/fragment_renderer/PageHead.js
@@ -3,8 +3,6 @@ import Head from "next/head";
 export default function PageHead(props) {
   return (
     <Head>
-      {props.adobeAnalyticsUrl ? <script src={props.adobeAnalyticsUrl} /> : ""}
-
       {/* Primary HTML Meta Tags */}
       <title>
         {props.locale === "en"

--- a/pages/404.js
+++ b/pages/404.js
@@ -36,12 +36,6 @@ export default function error404(props) {
     <>
       <main className="min-h-screen relative">
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="404">
             {pageData.scContentEn.json[0].content[0].value} (404) |{" "}
@@ -236,11 +230,6 @@ export default function error404(props) {
           </div>
         </footer>
       </main>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/500.js
+++ b/pages/500.js
@@ -36,12 +36,6 @@ export default function error500(props) {
     <>
       <main className="min-h-screen relative">
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="500">
             {pageData.scContentEn.json[0].content[0].value} (500) |{" "}
@@ -262,11 +256,6 @@ export default function error500(props) {
           </div>
         </footer>
       </main>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,11 +14,22 @@ class MyDocument extends Document {
   render() {
     return (
       <Html lang={this.props.lang === "default" ? "en" : this.props.lang}>
-        <Head />
+        <Head>
+          {process.env.ADOBE_ANALYTICS_URL ? (
+            <script src={process.env.ADOBE_ANALYTICS_URL} />
+          ) : (
+            ""
+          )}
+        </Head>
         <body>
           <Main />
           <NextScript />
           <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+          {process.env.ADOBE_ANALYTICS_URL ? (
+            <script type="text/javascript">_satellite.pageBottom()</script>
+          ) : (
+            ""
+          )}
         </body>
       </Html>
     );

--- a/pages/error.js
+++ b/pages/error.js
@@ -33,12 +33,6 @@ export default function ErrorPage(props) {
     <>
       <main className="min-h-screen relative">
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error={props.statusCode}>
             {pageData.scContentEn.json[0].content[0].value} |{" "}
@@ -441,11 +435,6 @@ export default function ErrorPage(props) {
           </div>
         </footer>
       </main>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/home.js
+++ b/pages/home.js
@@ -104,12 +104,6 @@ export default function Home(props) {
         dateModifiedOverride={pageData.scDateModifiedOverwrite}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
@@ -408,11 +402,6 @@ export default function Home(props) {
           </ul>
         </section>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,12 +20,6 @@ export default function Index(props) {
     <>
       <div className="splash-bg splash-image bg-splash-img-mobile xs:bg-splash-img bg-no-repeat fixed left-0 top-0 w-full h-full -z-1" />
       <Head>
-        {props.adobeAnalyticsUrl ? (
-          <script src={props.adobeAnalyticsUrl} />
-        ) : (
-          ""
-        )}
-
         {/* Primary HTML Meta Tags */}
         <title>Service Canada Labs | Laboratoires de Service Canada</title>
         <meta
@@ -185,11 +179,6 @@ export default function Index(props) {
           </div>
         </div>
       </main>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -33,12 +33,6 @@ export default function notSupported(props) {
     <>
       <main className="min-h-screen relative">
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="notSupported">
             {pageData.scContentEn.json[0].content[0].value} |{" "}
@@ -472,11 +466,6 @@ export default function notSupported(props) {
           </div>
         </footer>
       </main>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -32,11 +32,7 @@ export default function BenefitNavigatorArticles(props) {
           props.locale
         )}
       >
-        <PageHead
-          pageData={pageData}
-          adobeAnalyticsUrl={props.adobeAnalyticsUrl}
-          locale={props.locale}
-        />
+        <PageHead pageData={pageData} locale={props.locale} />
         <section className="mb-12">
           <div className="layout-container">
             <Heading
@@ -83,11 +79,6 @@ export default function BenefitNavigatorArticles(props) {
           </div>
         </section>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -82,12 +82,6 @@ export default function BenefitsNavigatorOverview(props) {
         )}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
@@ -726,11 +720,6 @@ export default function BenefitsNavigatorOverview(props) {
           </ul>
         </div>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -54,12 +54,6 @@ export default function MscaDashboard(props) {
         )}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
@@ -804,11 +798,6 @@ export default function MscaDashboard(props) {
           </section>
         </div>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -34,11 +34,7 @@ export default function DigitalStandardsArticles(props) {
           props.locale
         )}
       >
-        <PageHead
-          pageData={pageData}
-          adobeAnalyticsUrl={props.adobeAnalyticsUrl}
-          locale={props.locale}
-        />
+        <PageHead pageData={pageData} locale={props.locale} />
         <section className="mb-12">
           <div className="layout-container">
             <Heading
@@ -85,11 +81,6 @@ export default function DigitalStandardsArticles(props) {
           </div>
         </section>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -70,12 +70,6 @@ export default function DigitalStandardsPlaybookPage(props) {
         )}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
@@ -458,11 +452,6 @@ export default function DigitalStandardsPlaybookPage(props) {
           </section>
         </div>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -34,11 +34,7 @@ export default function IntegratedChannelStrategyArticles(props) {
           props.locale
         )}
       >
-        <PageHead
-          pageData={pageData}
-          adobeAnalyticsUrl={props.adobeAnalyticsUrl}
-          locale={props.locale}
-        />
+        <PageHead pageData={pageData} locale={props.locale} />
         <section className="mb-12">
           <div className="layout-container">
             <Heading
@@ -85,11 +81,6 @@ export default function IntegratedChannelStrategyArticles(props) {
           </div>
         </section>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -84,12 +84,6 @@ export default function IntegratedChannelStrategyPage(props) {
         )}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
@@ -363,11 +357,6 @@ export default function IntegratedChannelStrategyPage(props) {
           </ul>
         </div>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -34,11 +34,7 @@ export default function OASBenefitsEstimatorArticles(props) {
           props.locale
         )}
       >
-        <PageHead
-          pageData={pageData}
-          adobeAnalyticsUrl={props.adobeAnalyticsUrl}
-          locale={props.locale}
-        />
+        <PageHead pageData={pageData} locale={props.locale} />
         <section className="mb-12">
           <div className="layout-container">
             <Heading
@@ -85,11 +81,6 @@ export default function OASBenefitsEstimatorArticles(props) {
           </div>
         </section>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -81,12 +81,6 @@ export default function OasBenefitsEstimator(props) {
         )}
       >
         <Head>
-          {props.adobeAnalyticsUrl ? (
-            <script src={props.adobeAnalyticsUrl} />
-          ) : (
-            ""
-          )}
-
           {/* Primary HTML Meta Tags */}
           <title>
             {props.locale === "en"
@@ -418,11 +412,6 @@ export default function OasBenefitsEstimator(props) {
           </ul>
         </div>
       </Layout>
-      {props.adobeAnalyticsUrl ? (
-        <script type="text/javascript">_satellite.pageBottom()</script>
-      ) : (
-        ""
-      )}
     </>
   );
 }


### PR DESCRIPTION
This PR is to test moving our analytics scripts out of our page files and into the `_document.js` file, while retaining the data layer push within `useEffect` on the pages themselves.
