### PR TITLE
No default card height on mobile

### DIFF
--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -28,7 +28,7 @@ export const Card = (props) => {
         data-cy={props.dataCy}
       >
         {props.showImage ? (
-          <div className="h-80 flex justify-center">
+          <div className="sm:h-80 flex justify-center">
             <Image
               src={props.imgSrc}
               alt={props.imgAlt}


### PR DESCRIPTION
# [Remove excessive whitespace around images on mobile](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)

Before:
<img width="291" alt="Screenshot 2024-03-13 at 11 24 34 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/1fee9786-e158-44d6-93b9-56e1081e948e">

After:
<img width="286" alt="Screenshot 2024-03-13 at 11 24 59 AM" src="https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/38d9986c-91a4-4a7f-8efd-c0192ce8d9fb">
