### PR TITLE
Use nullish coalescing operator for analytics URL

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -240,7 +240,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations("en", ["common"])),
       ...(await serverSideTranslations("fr", ["common"])),
       pageData: data.sclabsErrorpageV1ByPath,

--- a/pages/500.js
+++ b/pages/500.js
@@ -266,7 +266,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations("en", ["common"])),
       ...(await serverSideTranslations("fr", ["common"])),
       pageData: data.sclabsErrorpageV1ByPath,

--- a/pages/home.js
+++ b/pages/home.js
@@ -417,7 +417,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       experimentsData: experimentsData.sclabsPageV1List.items,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/index.js
+++ b/pages/index.js
@@ -186,7 +186,7 @@ export default function Index(props) {
 export const getServerSideProps = async ({ locale }) => ({
   props: {
     locale: locale ?? "en",
-    adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? "",
+    adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
     ...(await serverSideTranslations(locale, ["common"])),
   },
 });

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -476,7 +476,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations("en", ["common"])),
       ...(await serverSideTranslations("fr", ["common"])),
       pageData: data.sclabsErrorpageV1ByPath,

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -127,7 +127,7 @@ export const getStaticProps = async ({ locale, params }) => {
       locale: locale,
       pageData: pageData[0],
       dictionary: dictionary.dictionaryV1List,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common", "vc"])),
     },
     revalidate: process.env.ENVIRONMENT === "development" ? 10 : false,

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -732,7 +732,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -805,7 +805,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -130,7 +130,7 @@ export const getStaticProps = async ({ locale, params }) => {
       locale: locale,
       pageData: pageData[0],
       dictionary: dictionary.dictionaryV1List,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),
     },
     revalidate: process.env.ENVIRONMENT === "development" ? 10 : false,

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -472,7 +472,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -130,7 +130,7 @@ export const getStaticProps = async ({ locale, params }) => {
       locale: locale,
       pageData: pageData[0],
       dictionary: dictionary.dictionaryV1List,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),
     },
     revalidate: process.env.ENVIRONMENT === "development" ? 10 : false,

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -367,7 +367,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -130,7 +130,7 @@ export const getStaticProps = async ({ locale, params }) => {
       locale: locale,
       pageData: pageData[0],
       dictionary: dictionary.dictionaryV1List,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),
     },
     revalidate: process.env.ENVIRONMENT === "development" ? 10 : false,

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -424,7 +424,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,


### PR DESCRIPTION
This PR simply adds the nullish coalescing operator to instances where pages get the analytics URL from the environment in getStaticProps. This prevents JSON errors that crash the app.
