### PR TITLE
Dashboard articles template + query + rewrite

### DIFF
--- a/graphql/queries/getMSCADashboardArticles.graphql
+++ b/graphql/queries/getMSCADashboardArticles.graphql
@@ -1,0 +1,342 @@
+query getMSCADashboardArticles {
+  sclabsPageV1List(
+    filter: {
+      scContentType: {
+        _expressions: [
+          {
+            value: "gc:content-types/promotional-material-featured-articles"
+            _operator: EQUALS
+          }
+        ]
+      }
+      _path: {
+        _expressions: [
+          {
+            value: "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/client-hub/project-updates/"
+            _operator: STARTS_WITH
+          }
+        ]
+      }
+    }
+  ) {
+    items {
+      _path
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scBreadcrumbParentPages {
+        ... on SclabsPageV1Model {
+          scTitleEn
+          scTitleFr
+          scPageNameEn
+          scPageNameFr
+        }
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+          _publishUrl
+          width
+          height
+        }
+        ... on DocumentRef {
+          _path
+          _publishUrl
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+          _publishUrl
+          width
+          height
+        }
+        ... on DocumentRef {
+          _path
+          _publishUrl
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SclabsCompContentV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          scId
+          scLabContent {
+            ... on SclabsContentV1Model {
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+            }
+          }
+          scLabLayout
+        }
+        ... on SclabsCompContentImageV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          scId
+          scLabContent {
+            scId
+            scContentEn {
+              json
+            }
+            scContentFr {
+              json
+            }
+          }
+          scLabImage {
+            ... on SclabsImageV1Model {
+              scId
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scImageCaptionEn {
+                json
+              }
+              scImageCaptionFr {
+                json
+              }
+            }
+          }
+          scLabLayout
+        }
+        ... on SclabsContentV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+        ... on SclabsImageV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          _path
+          scId
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageMobileFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scImageCaptionEn {
+            json
+          }
+          scImageCaptionFr {
+            json
+          }
+          scLongDescHeadingEn
+          scLongDescHeadingFr
+          scLongDescEn {
+            json
+          }
+          scLongDescFr {
+            json
+          }
+        }
+        ... on SclabsButtonV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SclabsFeatureV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on ImageRef {
+              _publishUrl
+              width
+              height
+            }
+            ... on DocumentRef {
+              _publishUrl
+            }
+          }
+          scImageAltTextFr
+          scFragments {
+            ... on SclabsAlertV1Model {
+              _path
+              scId
+              scTitleEn
+              scTitleFr
+              scContentEn {
+                json
+              }
+              scContentFr {
+                json
+              }
+              scAlertType
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
+            scId
+            scTitleEn
+            scTitleFr
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
+        }
+        ... on TooltipV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          _path
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,10 @@ const REWRITES = [
     destination: "/projects/dashboard",
   },
   {
+    source: "/projets/tableau-de-bord/:slug",
+    destination: "/projects/dashboard/:slug",
+  },
+  {
     source: "/projets/navigateur-prestations",
     destination: "/projects/benefits-navigator",
   },

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -1,0 +1,135 @@
+import PageHead from "../../../components/fragment_renderer/PageHead";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { Layout } from "../../../components/organisms/Layout";
+import { useEffect, useState } from "react";
+import aemServiceInstance from "../../../services/aemServiceInstance";
+import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
+import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
+import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
+import { Heading } from "../../../components/molecules/Heading";
+
+export default function MscaDashboardArticles(props) {
+  const [pageData] = useState(props.pageData);
+  const [dictionary] = useState(props.dictionary.items);
+
+  useEffect(() => {
+    if (props.adobeAnalyticsUrl) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
+
+  return (
+    <>
+      <Layout
+        locale={props.locale}
+        langUrl={
+          props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
+        }
+        dateModifiedOverride={pageData.scDateModifiedOverwrite}
+        breadcrumbItems={createBreadcrumbs(
+          pageData.scBreadcrumbParentPages,
+          props.locale
+        )}
+      >
+        <PageHead pageData={pageData} locale={props.locale} />
+        <section className="mb-12">
+          <div className="layout-container">
+            <Heading
+              tabIndex="-1"
+              id="pageMainTitle"
+              title={
+                props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr
+              }
+            />
+            <div id="postedOnUpdatedOnSection" className="grid grid-cols-12">
+              <p
+                className={`col-span-6 sm:col-span-4 ${
+                  props.locale === "en" ? "lg:col-span-2" : "lg:col-span-3"
+                } font-bold`}
+              >
+                {props.locale === "en"
+                  ? dictionary[9].scTermEn
+                  : dictionary[9].scTermFr}
+              </p>
+              <p className="col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5 mt-0">
+                {pageData.scDateModifiedOverwrite}
+              </p>
+              <p
+                className={`row-start-2 col-span-6 sm:col-span-4 mt-0 ${
+                  props.locale === "en" ? "lg:col-span-2" : "lg:col-span-3"
+                } font-bold`}
+              >
+                {props.locale === "en"
+                  ? dictionary[4].scTermEn
+                  : dictionary[4].scTermFr}
+              </p>
+              <p className="row-start-2 col-span-6 col-start-7 sm:col-start-5 lg:col-span-2 md:col-start-5 mt-auto">
+                {pageData.scDateModifiedOverwrite}
+              </p>
+            </div>
+          </div>
+
+          {/* Main */}
+          <div id="mainContentSection">
+            <FragmentRender
+              fragments={props.pageData.scFragments}
+              locale={props.locale}
+            />
+          </div>
+        </section>
+      </Layout>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  // Get pages data
+  const { data } = await aemServiceInstance.getFragment(
+    "benefitsNavigatorArticlesQuery"
+  );
+  // Get paths for dynamic routes from the page name data
+  const paths = getAllUpdateIds(data.sclabsPageV1List.items);
+  paths.map((path) => (path.params.id = path.params.id.split("/").at(-1)));
+  return {
+    paths,
+    fallback: "blocking",
+  };
+}
+
+export const getStaticProps = async ({ locale, params }) => {
+  // Get pages data
+  const { data } = await aemServiceInstance.getFragment(
+    "getMSCADashboardArticles"
+  );
+  // get dictionary
+  const { data: dictionary } = await aemServiceInstance.getFragment(
+    "dictionaryQuery"
+  );
+  const pages = data.sclabsPageV1List.items;
+  // Return page data that matches the current page being built
+  const pageData = pages.filter((page) => {
+    return (
+      (locale === "en" ? page.scPageNameEn : page.scPageNameFr)
+        .split("/")
+        .at(-1) === params.id
+    );
+  });
+
+  if (!pageData || !pageData.length) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      locale: locale,
+      pageData: pageData[0],
+      dictionary: dictionary.dictionaryV1List,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
+      ...(await serverSideTranslations(locale, ["common", "vc"])),
+    },
+    revalidate: process.env.ISR_ENABLED === "true" ? 10 : false,
+  };
+};

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -86,7 +86,7 @@ export default function MscaDashboardArticles(props) {
 export async function getStaticPaths() {
   // Get pages data
   const { data } = await aemServiceInstance.getFragment(
-    "benefitsNavigatorArticlesQuery"
+    "getMSCADashboardArticles"
   );
   // Get paths for dynamic routes from the page name data
   const paths = getAllUpdateIds(data.sclabsPageV1List.items);


### PR DESCRIPTION
# [Create and release article template file for Dashboard](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?System.AssignedTo=jordan.willis%40hrsdc-rhdcc.gc.ca)

This PR includes:

- Creation of the template file for MSCAD article pages
- Creation of the query to support fetching the MSCAD article pages
- Setup of rewrites to support french paths in MSCAD articles

## Test Instructions

Currently there is no content for MSCAD articles in AEM so testing will come with the first article being published in AEM
