### PR TITLE
Add id to h1 in cdcp-apply page and add text content to content skip button

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -45,7 +45,9 @@ export const Layout = ({
           data-cy-button={"skip-Content"}
           draggable="false"
           aria-label={t("skipToMainContentBtn")}
-        ></a>
+        >
+          {t("skipToMainContentBtn")}
+        </a>
       </nav>
       <header>
         <h2 className="sr-only">{t("globalHeader")}</h2>

--- a/pages/cdcp-apply.js
+++ b/pages/cdcp-apply.js
@@ -62,7 +62,10 @@ export default function CDCPLanding(props) {
             <p className="mt-12 text-multi-neutrals-grey85">
               {t("cdcp.secondaryHeading")}
             </p>
-            <h1 className="mt-0 mb-8 pb-2 border-b border-multi-red-red50a">
+            <h1
+              id="pageMainTitle"
+              className="mt-0 mb-8 pb-2 border-b border-multi-red-red50a"
+            >
               {t("cdcp.primaryHeading")}
             </h1>
           </div>


### PR DESCRIPTION
Added missing text content to button used for skipping to main content section
Added an id to the main heading in the cdcp-apply page

## Test Instructions

1. On the cdcp-apply page, use the Tab key
2. See that first item selected is the otherwise invisible "Skip to main content" button
