### PR TITLE
Add sizes property to next/Image instances to better optimize image sizes available to client

### DIFF
--- a/components/fragment_renderer/fragment_components/BasicTextWithImage.js
+++ b/components/fragment_renderer/fragment_components/BasicTextWithImage.js
@@ -7,7 +7,13 @@ export default function BasicTextWithImage({ src, alt, width, height, data }) {
       <div className="hidden lg:grid col-start-8 col-span-5 row-start-1 row-span-2">
         <div className="flex justify-center">
           <div className="h-auto">
-            <Image src={src} alt={alt} width={width} height={height} />
+            <Image
+              src={src}
+              alt={alt}
+              width={width}
+              height={height}
+              sizes="50vw"
+            />
           </div>
         </div>
       </div>

--- a/components/fragment_renderer/fragment_components/ImageWithCollapse.js
+++ b/components/fragment_renderer/fragment_components/ImageWithCollapse.js
@@ -21,6 +21,7 @@ export default function ImageWithCollapse({
         className="col-span-12 lg:col-span-10"
         width={width}
         height={height}
+        sizes="100vw"
       />
       <p className="grid row-start-2 col-span-12 lg:col-span-10 justify-around mb-8">
         {content}

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -35,6 +35,8 @@ export const Card = (props) => {
               className="object-contain"
               width={props.imgWidth}
               height={props.imgHeight}
+              // Cards are single column up to 768px
+              sizes="(max-width: 768px) 100vw, 50vw"
             />
           </div>
         ) : (

--- a/next.config.js
+++ b/next.config.js
@@ -118,11 +118,10 @@ module.exports = {
     return config;
   },
   images: {
-    domains: ['canada.ca', 'www.canada.ca'],
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'canada.ca',
+        hostname: '**.canada.ca',
         port: '',
       },
     ]

--- a/pages/home.js
+++ b/pages/home.js
@@ -287,6 +287,7 @@ export default function Home(props) {
                     alt=""
                     width={pageData.scFragments[1].scImageEn.width}
                     height={pageData.scFragments[1].scImageEn.height}
+                    sizes="33vw"
                     priority
                   />
                 </span>


### PR DESCRIPTION
# [Add sizes property to Card images to better optimize srcset](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=204087)

This PR add the `sizes` property to instances of the <Image> component. This will create a wider selection of responsive image sizes to be served across different viewport sizes.

Additionally this property has been added to nextjs/Image instances in BasicTextWithImage.js and ImageWithCollapse.js 

## Test Instructions

1. Navigate to homepage, inspect the image
2. See that srcset property of img tag contains images for 256w to 3840w
3. See the same for card images
