### PR TITLE
Use sharp package for image optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^13.5.0",
     "react-lock-scroll": "^0.1.8",
+    "sharp": "^0.33.3",
     "unified": "^10.1.2",
     "uuid": "^9.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14744,6 +14744,7 @@ __metadata:
     react-dom: "npm:^18.2.0"
     react-i18next: "npm:^13.5.0"
     react-lock-scroll: "npm:^0.1.8"
+    sharp: "npm:^0.33.3"
     storybook: "npm:^8.0.9"
     tailwindcss: "npm:^3.0.9"
     unified: "npm:^10.1.2"


### PR DESCRIPTION
# Use sharp to optimize images

By default, Nextjs image optimization uses [squoosh](https://www.npmjs.com/package/@squoosh/lib) to optimize images. Hidden in their documentation is this recommendation that [sharp](https://www.npmjs.com/package/sharp), rather than squoosh, be used in production.

I am hoping this improves performance and will be testing this in the dev environment.

## Test Instructions

1. yarn build + yarn start
2. Navigate the site
3. See that images render quickly and as expected
