### PR TITLE
Add nullish coalescing operator to error page AA check

### DIFF
--- a/pages/error.js
+++ b/pages/error.js
@@ -438,7 +438,7 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations("en", ["common"])),
       ...(await serverSideTranslations("fr", ["common"])),
       pageData: data.sclabsErrorpageV1ByPath,


### PR DESCRIPTION
# Add nullish coalescing operator to error page AA check

This is a small change to prevent the error page from throwing errors when there is no ADOBE_ANALYTICS_URL variable available to the environment
