### PR TITLE
TopNavBar Component

### DIFF
--- a/components/molecules/TopNavBar.js
+++ b/components/molecules/TopNavBar.js
@@ -29,7 +29,6 @@ export function TopNavBar({
   return (
     <div className="bg-custom-gray-lightest min-h-[64px] flex justify-end">
       {/* Desktop Nav Menu */}
-      {/* TODO get translation for aria labels */}
       <nav
         aria-label={ariaLabel}
         className="hidden lg:flex w-full self-center justify-between layout-container"
@@ -38,10 +37,10 @@ export function TopNavBar({
           {homeLinkLabel}
         </Link>
         <div className="lg:mr-16">
-          <Link href={projectsLink} className="mr-10 text-p">
+          <Link href={projectsLink} className="font-body mr-10 text-p">
             {projectsLinkLabel}
           </Link>
-          <Link href={updatesLink} className="text-p">
+          <Link href={updatesLink} className="font-body text-p">
             {updatesLinkLabel}
           </Link>
         </div>

--- a/components/molecules/TopNavBar.js
+++ b/components/molecules/TopNavBar.js
@@ -1,0 +1,144 @@
+import Link from "next/link";
+import React, { useState } from "react";
+
+export function TopNavBar({
+  homeLink,
+  homeLinkLabel,
+  updatesLink,
+  updatesLinkLabel,
+  projectsLink,
+  projectsLinkLabel,
+  ariaLabel,
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isTransitioningClosed, setIsTransitioningClosed] = useState(false);
+
+  //Handles the opening and closing of our nav
+  const handleClick = () => {
+    isOpen ? animateCloseMenu() : setIsOpen(!isOpen);
+  };
+
+  const animateCloseMenu = () => {
+    setIsTransitioningClosed(true);
+    setTimeout(() => {
+      setIsTransitioningClosed(false);
+      setIsOpen(!isOpen);
+    }, 250);
+  };
+
+  return (
+    <div className="bg-custom-gray-lightest min-h-[64px] flex justify-end">
+      {/* Desktop Nav Menu */}
+      {/* TODO get translation for aria labels */}
+      <nav
+        aria-label={ariaLabel}
+        className="hidden lg:flex w-full self-center justify-between layout-container"
+      >
+        <Link href={homeLink} className="font-body font-semibold text-h3">
+          {homeLinkLabel}
+        </Link>
+        <div className="lg:mr-16">
+          <Link href={projectsLink} className="mr-10 text-p">
+            {projectsLinkLabel}
+          </Link>
+          <Link href={updatesLink} className="text-p">
+            {updatesLinkLabel}
+          </Link>
+        </div>
+      </nav>
+      {/* Mobile Nav Menu */}
+      <nav
+        aria-label={ariaLabel}
+        className="static lg:hidden mt-5 flex flex-col w-full mr-4"
+      >
+        <button
+          aria-haspopup="true"
+          aria-expanded={isOpen ? "true" : "false"}
+          aria-controls="menu"
+          onClick={handleClick}
+          className="self-end"
+        >
+          {isOpen ? (
+            <div
+              className={`${
+                isTransitioningClosed ? "fade-out" : "fade-in"
+              } -mt-1 p-1.5`}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 17 17"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="exit-icon"
+              >
+                <path d="M11.3775 8.25L16.0683 3.55922C16.6439 2.98359 16.6439 2.05031 16.0683 1.47422L15.0258 0.431719C14.4502 -0.143906 13.5169 -0.143906 12.9408 0.431719L8.25 5.1225L3.55922 0.431719C2.98359 -0.143906 2.05031 -0.143906 1.47422 0.431719L0.431719 1.47422C-0.143906 2.04984 -0.143906 2.98312 0.431719 3.55922L5.1225 8.25L0.431719 12.9408C-0.143906 13.5164 -0.143906 14.4497 0.431719 15.0258L1.47422 16.0683C2.04984 16.6439 2.98359 16.6439 3.55922 16.0683L8.25 11.3775L12.9408 16.0683C13.5164 16.6439 14.4502 16.6439 15.0258 16.0683L16.0683 15.0258C16.6439 14.4502 16.6439 13.5169 16.0683 12.9408L11.3775 8.25Z" />
+              </svg>
+            </div>
+          ) : (
+            <div className={`${isTransitioningClosed ? "fade-in" : ""} -mt-1`}>
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4 18L20 18"
+                  stroke="#000000"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M4 12L20 12"
+                  stroke="#000000"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M4 6L20 6"
+                  stroke="#000000"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </div>
+          )}
+        </button>
+        {isOpen ? (
+          <ul
+            id="menu"
+            className={`${
+              isTransitioningClosed ? "fade-out" : "fade-in"
+            } absolute w-full flex flex-col mt-8 pb-4 bg-custom-gray-lightest drop-shadow-xl`}
+          >
+            <li
+              className={`${
+                isTransitioningClosed ? "decrease-margin" : "expand-margin"
+              } my-2 ml-4`}
+            >
+              <Link href={homeLink}>{homeLinkLabel}</Link>
+            </li>
+            <li
+              className={`${
+                isTransitioningClosed ? "decrease-margin" : "expand-margin"
+              } my-2 ml-4`}
+            >
+              <Link href={projectsLink}>{projectsLinkLabel}</Link>
+            </li>
+            <li
+              className={`${
+                isTransitioningClosed ? "decrease-margin" : "expand-margin"
+              } my-2 ml-4`}
+            >
+              <Link href={updatesLink}>{updatesLinkLabel}</Link>
+            </li>
+          </ul>
+        ) : (
+          ""
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/components/molecules/TopNavBar.js
+++ b/components/molecules/TopNavBar.js
@@ -8,7 +8,8 @@ export function TopNavBar({
   updatesLinkLabel,
   projectsLink,
   projectsLinkLabel,
-  ariaLabel,
+  navAriaLabel,
+  buttonAriaLabel,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [isTransitioningClosed, setIsTransitioningClosed] = useState(false);
@@ -27,12 +28,12 @@ export function TopNavBar({
   };
 
   return (
-    <div className="bg-custom-gray-lightest min-h-[64px] flex justify-end">
+    <nav
+      aria-label={navAriaLabel}
+      className="bg-custom-gray-lightest min-h-[64px] flex justify-end"
+    >
       {/* Desktop Nav Menu */}
-      <nav
-        aria-label={ariaLabel}
-        className="hidden lg:flex w-full self-center justify-between layout-container"
-      >
+      <div className="hidden lg:flex w-full self-center justify-between layout-container">
         <Link href={homeLink} className="font-body font-semibold text-h3">
           {homeLinkLabel}
         </Link>
@@ -44,13 +45,11 @@ export function TopNavBar({
             {updatesLinkLabel}
           </Link>
         </div>
-      </nav>
+      </div>
       {/* Mobile Nav Menu */}
-      <nav
-        aria-label={ariaLabel}
-        className="static lg:hidden mt-5 flex flex-col w-full mr-4"
-      >
+      <div className="static lg:hidden mt-5 flex flex-col w-full mr-4">
         <button
+          aria-label={buttonAriaLabel}
           aria-haspopup="true"
           aria-expanded={isOpen ? "true" : "false"}
           aria-controls="menu"
@@ -137,7 +136,7 @@ export function TopNavBar({
         ) : (
           ""
         )}
-      </nav>
-    </div>
+      </div>
+    </nav>
   );
 }

--- a/components/molecules/TopNavBar.stories.js
+++ b/components/molecules/TopNavBar.stories.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { TopNavBar } from "./TopNavBar";
+
+export default {
+  title: "Components/Molecules/TopNavBar",
+  component: TopNavBar,
+};
+
+const Template = (args) => <TopNavBar {...args}></TopNavBar>;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  homeLink: "#home",
+  homeLinkLabel: "Home",
+  updatesLink: "#updates",
+  updatesLinkLabel: "Updates",
+  projectsLink: "#projects",
+  projectsLinkLabel: "Projects",
+  navAriaLabel: "nav-aria-label",
+  buttonAriaLabel: "button-aria-label",
+};

--- a/components/molecules/TopNavBar.test.js
+++ b/components/molecules/TopNavBar.test.js
@@ -9,9 +9,21 @@ import { Primary } from "./TopNavBar.stories";
 expect.extend(toHaveNoViolations);
 
 describe("TopNavBar", () => {
-  it("renders the TopNavBar with expected props", () => {
+  it("renders the TopNavBar with expected props on desktop", () => {
     render(<Primary {...Primary.args} />);
     expect(screen.getByLabelText("nav-aria-label")).toBeTruthy();
+    expect(screen.getByLabelText("button-aria-label")).toBeTruthy();
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.getByText("Updates")).toBeTruthy();
+  });
+
+  it("renders the TopNavBar with expected props on mobile", () => {
+    render(<Primary {...Primary.args} />);
+    global.innerWidth = 500;
+    expect(screen.getByLabelText("nav-aria-label")).toBeTruthy();
+    expect(screen.getByLabelText("button-aria-label")).toBeTruthy();
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.getByText("Updates")).toBeTruthy();
   });
 
   it("has no a11y violations", async () => {

--- a/components/molecules/TopNavBar.test.js
+++ b/components/molecules/TopNavBar.test.js
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./TopNavBar.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("TopNavBar", () => {
+  it("renders the TopNavBar with expected props", () => {
+    render(<Primary {...Primary.args} />);
+    expect(screen.getByLabelText("nav-aria-label")).toBeTruthy();
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -35,7 +35,7 @@ export const Layout = ({
     typeof window !== "undefined" && window.location.origin
       ? window.location.href
       : "";
-  const isTopNavBarActive = true;
+  const isTopNavBarActive = false;
 
   return (
     <div className="overflow-x-hidden">

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -64,7 +64,7 @@ export const Layout = ({
         ) : (
           ""
         )}
-        <div className="layout-container lg:max-w-full mt-4 mb-3 lg:mx-0 lg:px-2 flex-col flex lg:flex lg:flex-row justify-between">
+        <div className="layout-container lg:max-w-full pt-4 pb-3 !mx-0 !px-5 flex-col flex lg:flex lg:flex-row justify-between bg-custom-gray-lightest">
           <div
             className="flex flex-row justify-between"
             role="navigation"

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -35,6 +35,7 @@ export const Layout = ({
     typeof window !== "undefined" && window.location.origin
       ? window.location.href
       : "";
+  const isTopNavBarActive = true;
 
   return (
     <div className="overflow-x-hidden">
@@ -108,15 +109,18 @@ export const Layout = ({
           </div>
         </div>
         <div className="border-b-[3px] border-multi-blue-blue35" />
-        <TopNavBar
-          homeLink={t("topNavBar.homeLink")}
-          homeLinkLabel={t("topNavBar.homeLinkLabel")}
-          updatesLink={t("topNavBar.updatesLink")}
-          updatesLinkLabel={t("topNavBar.updatesLinkLabel")}
-          projectsLink={t("topNavBar.projectsLink")}
-          projectsLinkLabel={t("topNavBar.projectsLinkLabel")}
-          ariaLabel={t("topNavBar.ariaLabel")}
-        />
+        {isTopNavBarActive ? (
+          <TopNavBar
+            homeLink={t("topNavBar.homeLink")}
+            homeLinkLabel={t("topNavBar.homeLinkLabel")}
+            updatesLink={t("topNavBar.updatesLink")}
+            updatesLinkLabel={t("topNavBar.updatesLinkLabel")}
+            projectsLink={t("topNavBar.projectsLink")}
+            projectsLinkLabel={t("topNavBar.projectsLinkLabel")}
+            navAriaLabel={t("topNavBar.ariaLabel")}
+            buttonAriaLabel={t("topNavBar.buttonAriaLabel")}
+          />
+        ) : null}
         <div className="layout-container mt-4">
           <Breadcrumb items={breadcrumbItems} />
         </div>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -7,6 +7,7 @@ import { DateModified } from "../atoms/DateModified";
 import { Breadcrumb } from "../atoms/Breadcrumb";
 import { Footer } from "../organisms/Footer";
 import Feedback from "./Feedback";
+import { TopNavBar } from "../molecules/TopNavBar";
 
 /**
  * Component which defines the layout of the page for all screen sizes
@@ -63,7 +64,7 @@ export const Layout = ({
         ) : (
           ""
         )}
-        <div className="layout-container lg:max-w-full mt-4 mb-4 lg:mx-0 lg:px-2 flex-col flex lg:flex lg:flex-row justify-between">
+        <div className="layout-container lg:max-w-full mt-4 mb-3 lg:mx-0 lg:px-2 flex-col flex lg:flex lg:flex-row justify-between">
           <div
             className="flex flex-row justify-between"
             role="navigation"
@@ -87,7 +88,7 @@ export const Layout = ({
               href={langUrl}
               locale={language}
               data-testid="languageLink1"
-              className="block lg:hidden ml-6 -m-1 sm:ml-16 underline underline-offset-[6px] font-body text-canada-footer-font lg:text-sm text-lg hover:text-canada-footer-hover-font-blue"
+              className="block lg:hidden ml-6 -mt-1 sm:ml-16 underline underline-offset-[6px] font-body text-canada-footer-font lg:text-sm text-lg hover:text-canada-footer-hover-font-blue"
             >
               {language === "en" ? "EN" : "FR"}
             </Link>
@@ -107,8 +108,16 @@ export const Layout = ({
           </div>
         </div>
         <div className="border-b-[3px] border-multi-blue-blue35" />
-
-        <div className="layout-container mt-4 lg:mt-20">
+        <TopNavBar
+          homeLink={t("topNavBar.homeLink")}
+          homeLinkLabel={t("topNavBar.homeLinkLabel")}
+          updatesLink={t("topNavBar.updatesLink")}
+          updatesLinkLabel={t("topNavBar.updatesLinkLabel")}
+          projectsLink={t("topNavBar.projectsLink")}
+          projectsLinkLabel={t("topNavBar.projectsLinkLabel")}
+          ariaLabel={t("topNavBar.ariaLabel")}
+        />
+        <div className="layout-container mt-4">
           <Breadcrumb items={breadcrumbItems} />
         </div>
       </header>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -63,9 +63,9 @@ export const Layout = ({
         ) : (
           ""
         )}
-        <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between mt-2">
+        <div className="layout-container lg:max-w-full mt-4 mb-4 lg:mx-0 lg:px-2 flex-col flex lg:flex lg:flex-row justify-between">
           <div
-            className="flex flex-row justify-between items-center lg:mt-7 mt-1.5"
+            className="flex flex-row justify-between"
             role="navigation"
             aria-labelledby="officialSiteNav"
           >
@@ -78,6 +78,7 @@ export const Layout = ({
                 alt={t("symbol")}
                 width="375"
                 height="35"
+                className="max-w-[280px]"
               />
             </a>
             <h3 className="sr-only">{t("languageSelection")}</h3>
@@ -86,18 +87,18 @@ export const Layout = ({
               href={langUrl}
               locale={language}
               data-testid="languageLink1"
-              className="visible lg:invisible ml-6 sm:ml-16 underline font-body font-bold text-canada-footer-font lg:text-sm text-base hover:text-canada-footer-hover-font-blue"
+              className="block lg:hidden ml-6 -m-1 sm:ml-16 underline underline-offset-[6px] font-body text-canada-footer-font lg:text-sm text-lg hover:text-canada-footer-hover-font-blue"
             >
               {language === "en" ? "EN" : "FR"}
             </Link>
           </div>
-          <div className="flex-col flex">
+          <div className="flex flex-col justify-center">
             <Link
               key={language}
               href={langUrl}
               locale={language}
               data-testid="languageLink3"
-              className="lg:visible invisible pb-0 lg:pb-2 self-end underline font-body text-canada-footer-font hover:text-canada-footer-hover-font-blue"
+              className="flex lg:block hidden underline underline-offset-[5px] font-body text-canada-footer-font hover:text-canada-footer-hover-font-blue"
               data-cy="toggle-language-link"
               lang={language}
             >
@@ -105,6 +106,7 @@ export const Layout = ({
             </Link>
           </div>
         </div>
+        <div className="border-b-[3px] border-multi-blue-blue35" />
 
         <div className="layout-container mt-4 lg:mt-20">
           <Breadcrumb items={breadcrumbItems} />

--- a/components/text_node_renderer/nodes/ListItem.jsx
+++ b/components/text_node_renderer/nodes/ListItem.jsx
@@ -1,3 +1,3 @@
 export default function ListItem(props) {
-  return <li>{props.children}</li>;
+  return <li className="ml-10 text-[20px]">{props.children}</li>;
 }

--- a/components/text_node_renderer/nodes/OrderedList.jsx
+++ b/components/text_node_renderer/nodes/OrderedList.jsx
@@ -1,3 +1,3 @@
 export default function UnorderedList(props) {
-  return <ol>{props.children}</ol>;
+  return <ol className="list-decimal">{props.children}</ol>;
 }

--- a/components/text_node_renderer/nodes/UnorderedList.jsx
+++ b/components/text_node_renderer/nodes/UnorderedList.jsx
@@ -1,3 +1,3 @@
 export default function UnorderedList(props) {
-  return <ul>{props.children}</ul>;
+  return <ul className="list-disc">{props.children}</ul>;
 }

--- a/pages/home.js
+++ b/pages/home.js
@@ -309,8 +309,8 @@ export default function Home(props) {
                   : pageData.scFragments[0].scContentFr.json[4].content[0]
                       .value}{" "}
               </p>
-              <ul>
-                <li>
+              <ul className="list-disc">
+                <li className="ml-10">
                   <p className="font-body">
                     {props.locale === "en"
                       ? pageData.scFragments[0].scContentEn.json[5].content[0]
@@ -319,7 +319,7 @@ export default function Home(props) {
                           .content[0].value}{" "}
                   </p>
                 </li>
-                <li>
+                <li className="ml-10">
                   <p className="font-body">
                     {props.locale === "en"
                       ? pageData.scFragments[0].scContentEn.json[5].content[1]

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -11,6 +11,7 @@ import { Collapse } from "../../../components/molecules/Collapse";
 import { generateCollapseElements } from "../../../lib/utils/generateCollapseElements";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import TextRender from "../../../components/text_node_renderer/TextRender";
 
 export default function BenefitsNavigatorOverview(props) {
   const [pageData] = useState(props.pageData.item);
@@ -417,43 +418,15 @@ export default function BenefitsNavigatorOverview(props) {
                 </div>
                 <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                   <div className="py-4 pl-4 border-l-4 border-multi-blue-blue60f">
-                    <h3 className="mb-2">
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[0].scContentEn
-                            .json[0].content[0].value
-                        : pageData.scFragments[4].scFragments[0].scContentFr
-                            .json[0].content[0].value}
-                    </h3>
-                    <p>
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[0].scContentEn
-                            .json[1].content[0].value
-                        : pageData.scFragments[4].scFragments[0].scContentFr
-                            .json[1].content[0].value}
-                    </p>
-                    <ul>
-                      <li>
-                        {props.locale === "en"
+                    <TextRender
+                      data={
+                        props.locale === "en"
                           ? pageData.scFragments[4].scFragments[0].scContentEn
-                              .json[2].content[0].content[0].value
+                              .json
                           : pageData.scFragments[4].scFragments[0].scContentFr
-                              .json[2].content[0].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[0].scContentEn
-                              .json[2].content[1].content[0].value
-                          : pageData.scFragments[4].scFragments[0].scContentFr
-                              .json[2].content[1].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[0].scContentEn
-                              .json[2].content[2].content[0].value
-                          : pageData.scFragments[4].scFragments[0].scContentFr
-                              .json[2].content[2].content[0].value}
-                      </li>
-                    </ul>
+                              .json
+                      }
+                    />
                   </div>
                 </div>
                 <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -466,13 +439,17 @@ export default function BenefitsNavigatorOverview(props) {
                         : pageData.scFragments[4].scFragments[0].scFragments[0]
                             .scLongDescHeadingFr
                     }
-                    children={generateCollapseElements(
-                      props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[0].scFragments[0]
-                            .scLongDescEn.json
-                        : pageData.scFragments[4].scFragments[0].scFragments[0]
-                            .scLongDescFr.json
-                    )}
+                    children={
+                      <TextRender
+                        data={
+                          props.locale === "en"
+                            ? pageData.scFragments[4].scFragments[0]
+                                .scFragments[0].scLongDescEn.json
+                            : pageData.scFragments[4].scFragments[0]
+                                .scFragments[0].scLongDescFr.json
+                        }
+                      />
+                    }
                   />
                 </div>
               </div>
@@ -507,43 +484,15 @@ export default function BenefitsNavigatorOverview(props) {
                 </div>
                 <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                   <div className="p-4 border-l-4 border-multi-blue-blue60f">
-                    <h3 className="mb-2">
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[1].scContentEn
-                            .json[0].content[0].value
-                        : pageData.scFragments[4].scFragments[1].scContentFr
-                            .json[0].content[0].value}
-                    </h3>
-                    <p>
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[1].scContentEn
-                            .json[1].content[0].value
-                        : pageData.scFragments[4].scFragments[1].scContentFr
-                            .json[1].content[0].value}
-                    </p>
-                    <ul>
-                      <li>
-                        {props.locale === "en"
+                    <TextRender
+                      data={
+                        props.locale === "en"
                           ? pageData.scFragments[4].scFragments[1].scContentEn
-                              .json[2].content[0].content[0].value
+                              .json
                           : pageData.scFragments[4].scFragments[1].scContentFr
-                              .json[2].content[0].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[1].scContentEn
-                              .json[2].content[1].content[0].value
-                          : pageData.scFragments[4].scFragments[1].scContentFr
-                              .json[2].content[1].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[1].scContentEn
-                              .json[2].content[2].content[0].value
-                          : pageData.scFragments[4].scFragments[1].scContentFr
-                              .json[2].content[2].content[0].value}
-                      </li>
-                    </ul>
+                              .json
+                      }
+                    />
                   </div>
                 </div>
                 <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -556,13 +505,17 @@ export default function BenefitsNavigatorOverview(props) {
                         : pageData.scFragments[4].scFragments[1].scFragments[0]
                             .scLongDescHeadingFr
                     }
-                    children={generateCollapseElements(
-                      props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[1].scFragments[0]
-                            .scLongDescEn.json
-                        : pageData.scFragments[4].scFragments[1].scFragments[0]
-                            .scLongDescFr.json
-                    )}
+                    children={
+                      <TextRender
+                        data={
+                          props.locale === "en"
+                            ? pageData.scFragments[4].scFragments[1]
+                                .scFragments[0].scLongDescEn.json
+                            : pageData.scFragments[4].scFragments[1]
+                                .scFragments[0].scLongDescFr.json
+                        }
+                      />
+                    }
                   />
                 </div>
               </div>
@@ -597,57 +550,15 @@ export default function BenefitsNavigatorOverview(props) {
                 </div>
                 <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                   <div className="p-4 border-l-4 border-multi-blue-blue60f">
-                    <h3 className="mb-2">
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[2].scContentEn
-                            .json[0].content[0].value
-                        : pageData.scFragments[4].scFragments[2].scContentFr
-                            .json[0].content[0].value}
-                    </h3>
-                    <p>
-                      {props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[2].scContentEn
-                            .json[1].content[0].value
-                        : pageData.scFragments[4].scFragments[2].scContentFr
-                            .json[1].content[0].value}
-                    </p>
-                    <ul>
-                      <li>
-                        {props.locale === "en"
+                    <TextRender
+                      data={
+                        props.locale === "en"
                           ? pageData.scFragments[4].scFragments[2].scContentEn
-                              .json[2].content[0].content[0].value
+                              .json
                           : pageData.scFragments[4].scFragments[2].scContentFr
-                              .json[2].content[0].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[2].scContentEn
-                              .json[2].content[1].content[0].value
-                          : pageData.scFragments[4].scFragments[2].scContentFr
-                              .json[2].content[1].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[2].scContentEn
-                              .json[2].content[2].content[0].value
-                          : pageData.scFragments[4].scFragments[2].scContentFr
-                              .json[2].content[2].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[2].scContentEn
-                              .json[2].content[3].content[0].value
-                          : pageData.scFragments[4].scFragments[2].scContentFr
-                              .json[2].content[3].content[0].value}
-                      </li>
-                      <li>
-                        {props.locale === "en"
-                          ? pageData.scFragments[4].scFragments[2].scContentEn
-                              .json[2].content[4].content[0].value
-                          : pageData.scFragments[4].scFragments[2].scContentFr
-                              .json[2].content[4].content[0].value}
-                      </li>
-                    </ul>
+                              .json
+                      }
+                    />
                   </div>
                 </div>
                 <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -660,13 +571,17 @@ export default function BenefitsNavigatorOverview(props) {
                         : pageData.scFragments[4].scFragments[2].scFragments[0]
                             .scLongDescHeadingFr
                     }
-                    children={generateCollapseElements(
-                      props.locale === "en"
-                        ? pageData.scFragments[4].scFragments[2].scFragments[0]
-                            .scLongDescEn.json
-                        : pageData.scFragments[4].scFragments[2].scFragments[0]
-                            .scLongDescFr.json
-                    )}
+                    children={
+                      <TextRender
+                        data={
+                          props.locale === "en"
+                            ? pageData.scFragments[4].scFragments[2]
+                                .scFragments[0].scLongDescEn.json
+                            : pageData.scFragments[4].scFragments[2]
+                                .scFragments[0].scLongDescFr.json
+                        }
+                      />
+                    }
                   />
                 </div>
               </div>

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -11,6 +11,7 @@ import { generateCollapseElements } from "../../../lib/utils/generateCollapseEle
 import { ActionButton } from "../../../components/atoms/ActionButton";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import TextRender from "../../../components/text_node_renderer/TextRender";
 
 export default function MscaDashboard(props) {
   const pageData = props.pageData?.item;
@@ -408,36 +409,15 @@ export default function MscaDashboard(props) {
                   </div>
                   <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                     <div className="py-4 pl-4 border-l-4 border-multi-blue-blue60f">
-                      <h3 className="mb-2">
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[0].scContentEn
-                              .json[0].content[0].value
-                          : pageData.scFragments[5].scFragments[0].scContentFr
-                              .json[0].content[0].value}
-                      </h3>
-                      <p>
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[0].scContentEn
-                              .json[1].content[0].value
-                          : pageData.scFragments[5].scFragments[0].scContentFr
-                              .json[1].content[0].value}
-                      </p>
-                      <ul>
-                        <li>
-                          {props.locale === "en"
+                      <TextRender
+                        data={
+                          props.locale === "en"
                             ? pageData.scFragments[5].scFragments[0].scContentEn
-                                .json[2].content[0].content[0].value
+                                .json
                             : pageData.scFragments[5].scFragments[0].scContentFr
-                                .json[2].content[0].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[0].scContentEn
-                                .json[2].content[1].content[0].value
-                            : pageData.scFragments[5].scFragments[0].scContentFr
-                                .json[2].content[1].content[0].value}
-                        </li>
-                      </ul>
+                                .json
+                        }
+                      />
                     </div>
                   </div>
                   <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -450,13 +430,17 @@ export default function MscaDashboard(props) {
                           : pageData.scFragments[5].scFragments[0]
                               .scFragments[0].scLongDescHeadingFr
                       }
-                      children={generateCollapseElements(
-                        props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[0]
-                              .scFragments[0].scLongDescEn.json
-                          : pageData.scFragments[5].scFragments[0]
-                              .scFragments[0].scLongDescFr.json
-                      )}
+                      children={
+                        <TextRender
+                          data={
+                            props.locale === "en"
+                              ? pageData.scFragments[5].scFragments[0]
+                                  .scFragments[0].scLongDescEn.json
+                              : pageData.scFragments[5].scFragments[0]
+                                  .scFragments[0].scLongDescFr.json
+                          }
+                        />
+                      }
                     />
                   </div>
                 </div>
@@ -491,36 +475,15 @@ export default function MscaDashboard(props) {
                   </div>
                   <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                     <div className="p-4 border-l-4 border-multi-blue-blue60f">
-                      <h3 className="mb-2">
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[1].scContentEn
-                              .json[0].content[0].value
-                          : pageData.scFragments[5].scFragments[1].scContentFr
-                              .json[0].content[0].value}
-                      </h3>
-                      <p>
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[1].scContentEn
-                              .json[1].content[0].value
-                          : pageData.scFragments[5].scFragments[1].scContentFr
-                              .json[1].content[0].value}
-                      </p>
-                      <ul>
-                        <li>
-                          {props.locale === "en"
+                      <TextRender
+                        data={
+                          props.locale === "en"
                             ? pageData.scFragments[5].scFragments[1].scContentEn
-                                .json[2].content[0].content[0].value
+                                .json
                             : pageData.scFragments[5].scFragments[1].scContentFr
-                                .json[2].content[0].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[1].scContentEn
-                                .json[2].content[1].content[0].value
-                            : pageData.scFragments[5].scFragments[1].scContentFr
-                                .json[2].content[1].content[0].value}
-                        </li>
-                      </ul>
+                                .json
+                        }
+                      />
                     </div>
                   </div>
                   <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -533,13 +496,17 @@ export default function MscaDashboard(props) {
                           : pageData.scFragments[5].scFragments[1]
                               .scFragments[0].scLongDescHeadingFr
                       }
-                      children={generateCollapseElements(
-                        props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[1]
-                              .scFragments[0].scLongDescEn.json
-                          : pageData.scFragments[5].scFragments[1]
-                              .scFragments[0].scLongDescFr.json
-                      )}
+                      children={
+                        <TextRender
+                          data={
+                            props.locale === "en"
+                              ? pageData.scFragments[5].scFragments[1]
+                                  .scFragments[0].scLongDescEn.json
+                              : pageData.scFragments[5].scFragments[1]
+                                  .scFragments[0].scLongDescFr.json
+                          }
+                        />
+                      }
                     />
                   </div>
                 </div>
@@ -574,64 +541,15 @@ export default function MscaDashboard(props) {
                   </div>
                   <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                     <div className="p-4 border-l-4 border-multi-blue-blue60f">
-                      <h3 className="mb-2">
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[2].scContentEn
-                              .json[0].content[0].value
-                          : pageData.scFragments[5].scFragments[2].scContentFr
-                              .json[0].content[0].value}
-                      </h3>
-                      <p>
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[2].scContentEn
-                              .json[1].content[0].value
-                          : pageData.scFragments[5].scFragments[2].scContentFr
-                              .json[1].content[0].value}
-                      </p>
-                      <ul>
-                        <li>
-                          {props.locale === "en"
+                      <TextRender
+                        data={
+                          props.locale === "en"
                             ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[0].content[0].value
+                                .json
                             : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[0].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[1].content[0].value
-                            : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[1].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[2].content[0].value
-                            : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[2].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[3].content[0].value
-                            : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[3].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[4].content[0].value
-                            : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[4].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[2].scContentEn
-                                .json[2].content[5].content[0].value
-                            : pageData.scFragments[5].scFragments[2].scContentFr
-                                .json[2].content[5].content[0].value}
-                        </li>
-                      </ul>
+                                .json
+                        }
+                      />
                     </div>
                   </div>
                   <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -644,13 +562,17 @@ export default function MscaDashboard(props) {
                           : pageData.scFragments[5].scFragments[2]
                               .scFragments[0].scLongDescHeadingFr
                       }
-                      children={generateCollapseElements(
-                        props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[2]
-                              .scFragments[0].scLongDescEn.json
-                          : pageData.scFragments[5].scFragments[2]
-                              .scFragments[0].scLongDescFr.json
-                      )}
+                      children={
+                        <TextRender
+                          data={
+                            props.locale === "en"
+                              ? pageData.scFragments[5].scFragments[2]
+                                  .scFragments[0].scLongDescEn.json
+                              : pageData.scFragments[5].scFragments[2]
+                                  .scFragments[0].scLongDescFr.json
+                          }
+                        />
+                      }
                     />
                   </div>
                 </div>
@@ -685,50 +607,15 @@ export default function MscaDashboard(props) {
                   </div>
                   <div className="col-span-12 row-start-3 xl:col-span-4 xl:row-start-1">
                     <div className="p-4 border-l-4 border-multi-blue-blue60f">
-                      <h3 className="mb-2">
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[3].scContentEn
-                              .json[0].content[0].value
-                          : pageData.scFragments[5].scFragments[3].scContentFr
-                              .json[0].content[0].value}
-                      </h3>
-                      <p>
-                        {props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[3].scContentEn
-                              .json[1].content[0].value
-                          : pageData.scFragments[5].scFragments[3].scContentFr
-                              .json[1].content[0].value}
-                      </p>
-                      <ul>
-                        <li>
-                          {props.locale === "en"
+                      <TextRender
+                        data={
+                          props.locale === "en"
                             ? pageData.scFragments[5].scFragments[3].scContentEn
-                                .json[2].content[0].content[0].value
+                                .json
                             : pageData.scFragments[5].scFragments[3].scContentFr
-                                .json[2].content[0].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[3].scContentEn
-                                .json[2].content[1].content[0].value
-                            : pageData.scFragments[5].scFragments[3].scContentFr
-                                .json[2].content[1].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[3].scContentEn
-                                .json[2].content[2].content[0].value
-                            : pageData.scFragments[5].scFragments[3].scContentFr
-                                .json[2].content[2].content[0].value}
-                        </li>
-                        <li>
-                          {props.locale === "en"
-                            ? pageData.scFragments[5].scFragments[3].scContentEn
-                                .json[2].content[3].content[0].value
-                            : pageData.scFragments[5].scFragments[3].scContentFr
-                                .json[2].content[3].content[0].value}
-                        </li>
-                      </ul>
+                                .json
+                        }
+                      />
                     </div>
                   </div>
                   <div className="mb-6 col-span-12 xl:col-span-8 row-start-2 xl:row-start-2">
@@ -741,13 +628,17 @@ export default function MscaDashboard(props) {
                           : pageData.scFragments[5].scFragments[3]
                               .scFragments[0].scLongDescHeadingFr
                       }
-                      children={generateCollapseElements(
-                        props.locale === "en"
-                          ? pageData.scFragments[5].scFragments[3]
-                              .scFragments[0].scLongDescEn.json
-                          : pageData.scFragments[5].scFragments[3]
-                              .scFragments[0].scLongDescFr.json
-                      )}
+                      children={
+                        <TextRender
+                          data={
+                            props.locale === "en"
+                              ? pageData.scFragments[5].scFragments[3]
+                                  .scFragments[0].scLongDescEn.json
+                              : pageData.scFragments[5].scFragments[3]
+                                  .scFragments[0].scLongDescFr.json
+                          }
+                        />
+                      }
                     />
                   </div>
                 </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -541,7 +541,8 @@
   },
 
   "topNavBar": {
-    "ariaLabel": "navigation menu",
+    "navAriaLabel": "navigation menu",
+    "buttonAriaLabel": "navigation menu button",
     "homeLink": "/home",
     "homeLinkLabel": "Service Canada Labs",
     "projectsLink": "/projects",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -538,5 +538,15 @@
     "buttonLink": "https://d-d.alpha.service.canada.ca/en/apply/",
     "cdcpPreFooterLinkText": "Contact Us",
     "cdcpPreFooterLinkUrl": "https://www.canada.ca/en/contact.html"
+  },
+
+  "topNavBar": {
+    "ariaLabel": "navigation menu",
+    "homeLink": "/home",
+    "homeLinkLabel": "Service Canada Labs",
+    "projectsLink": "/projects",
+    "projectsLinkLabel": "Projects",
+    "updatesLink": "/updates",
+    "updatesLinkLabel": "Updates"
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -531,7 +531,8 @@
   },
 
   "topNavBar": {
-    "ariaLabel": "menu de navigation",
+    "navAriaLabel": "menu de navigation",
+    "buttonAriaLabel": "bouton du menu de navigation",
     "homeLink": "/accueil",
     "homeLinkLabel": "Laboratoires de Service Canada",
     "projectsLink": "/projects",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -528,5 +528,15 @@
     "buttonLink": "https://d-d.alpha.service.canada.ca/fr/demander",
     "cdcpPreFooterLinkText": "Contactez-nous",
     "cdcpPreFooterLinkUrl": "https://www.canada.ca/fr/contact.html"
+  },
+
+  "topNavBar": {
+    "ariaLabel": "menu de navigation",
+    "homeLink": "/accueil",
+    "homeLinkLabel": "Laboratoires de Service Canada",
+    "projectsLink": "/projects",
+    "projectsLinkLabel": "Projets",
+    "updatesLink": "/updates",
+    "updatesLinkLabel": "Mises à jour"
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -64,18 +64,6 @@ html {
     }
   }
 
-  /* Lists */
-  ul {
-    @apply list-disc;
-  }
-  ol {
-    @apply list-decimal;
-  }
-  li {
-    @apply ml-10;
-    @apply text-[20px];
-  }
-
   /* Content Element Styles */
   h1,
   h2 {

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -42,3 +42,60 @@
     padding-left: 2rem;
   }
 }
+
+/* Top Nav Menu */
+.fade-in {
+  animation: fade-in 0.3s;
+}
+
+.fade-out {
+  animation: fade-out 0.3s;
+}
+
+.expand-margin {
+  animation: expand-margin 0.3s;
+}
+
+.decrease-margin {
+  animation: decrease-margin 0.3s;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes expand-margin {
+  from {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  to {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+}
+
+@keyframes decrease-margin {
+  from {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+  to {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,7 +46,7 @@ module.exports = {
       sm: ["16px", "22px"],
       base: ["18px", "28px"],
       lg: ["20px", "32px"],
-      p: ["20px", "33px"],
+      p: ["20px", "30px"],
       h4: ["22px", "24px"],
       h3: ["24px", "26px"],
       h2: ["32px", "36px"],
@@ -225,6 +225,7 @@ module.exports = {
           darker: "#D3080C",
         },
         "custom-gray": {
+          lightest: "#F9F9F9",
           lighter: "#EEEEEE",
           darker: "#ACACAC",
           index: "#F8F8F8",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -144,6 +144,7 @@ module.exports = {
             blue60g: "#1C578A",
             blue50a: "#2572B4",
             blue50b: "#0535D2",
+            blue35: "#31455C",
             blue30: "#7B92B0",
             blue15: "#B0C1D7",
             blue5: "#DBE5F2",


### PR DESCRIPTION
# [Create and add new top nav component to Layout.js](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=215263)

This PR includes the new Nav bar that can be found in the new page designs as well as an accompanying story entry and unit test.

Figma:
https://www.figma.com/design/ke3SrZNGMP3AjwzMMuEgbo/%5Bcurrent%5D-BDM-DECD-SC-Labs?node-id=19176-10517&t=VRowRYItSVefILJe-4

Desktop:
![Screenshot 2024-06-04 at 3 39 59 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/ab12e696-3e9e-4d78-984a-cd9cad5ba5a5)

Mobile:
![Screenshot 2024-06-04 at 3 39 17 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/556e10c5-ee1b-4fc4-84bf-bed1bbdb0755)

By default, the TopNavBar is not active on the page. This is because it has links to pages that do not currently exist. The plan is to make it active when the new pages are ready. Nonetheless, I wanted to merge this branch as it includes some modifications to our default styles to `<ul>, <ol> and <li>` elements as well as some smaller tweaks.

Basically, list elements will by default have no styling so that we don't have to reverse default styles when using lists in certain contexts (like the nav menu in this PR). I've reviewed and made the appropriate changes to all pages where we use these elements, and applied the old default styles to the list elements in our TextNodeRender and FragmentRender so generated content should always be styled as we expect.

## Test Instructions

1. Go to Layout.js and set `isTopNavBarActive` to `true`
2. `yarn dev`
3. Navigate to home page or any other page
4. See that TopNavBar renders correctly, toggle language, and is desktop and mobile responsive
