### PR TITLE
Fix svg attribute names + make TopNav active

### DIFF
--- a/components/molecules/TopNavBar.js
+++ b/components/molecules/TopNavBar.js
@@ -85,20 +85,20 @@ export function TopNavBar({
                 <path
                   d="M4 18L20 18"
                   stroke="#000000"
-                  stroke-width="2"
-                  stroke-linecap="round"
+                  strokeWidth="2"
+                  strokeLinecap="round"
                 />
                 <path
                   d="M4 12L20 12"
                   stroke="#000000"
-                  stroke-width="2"
-                  stroke-linecap="round"
+                  strokeWidth="2"
+                  strokeLinecap="round"
                 />
                 <path
                   d="M4 6L20 6"
                   stroke="#000000"
-                  stroke-width="2"
-                  stroke-linecap="round"
+                  strokeWidth="2"
+                  strokeLinecap="round"
                 />
               </svg>
             </div>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -35,7 +35,6 @@ export const Layout = ({
     typeof window !== "undefined" && window.location.origin
       ? window.location.href
       : "";
-  const isTopNavBarActive = false;
 
   return (
     <div className="overflow-x-hidden">
@@ -109,18 +108,16 @@ export const Layout = ({
           </div>
         </div>
         <div className="border-b-[3px] border-multi-blue-blue35" />
-        {isTopNavBarActive ? (
-          <TopNavBar
-            homeLink={t("topNavBar.homeLink")}
-            homeLinkLabel={t("topNavBar.homeLinkLabel")}
-            updatesLink={t("topNavBar.updatesLink")}
-            updatesLinkLabel={t("topNavBar.updatesLinkLabel")}
-            projectsLink={t("topNavBar.projectsLink")}
-            projectsLinkLabel={t("topNavBar.projectsLinkLabel")}
-            navAriaLabel={t("topNavBar.ariaLabel")}
-            buttonAriaLabel={t("topNavBar.buttonAriaLabel")}
-          />
-        ) : null}
+        <TopNavBar
+          homeLink={t("topNavBar.homeLink")}
+          homeLinkLabel={t("topNavBar.homeLinkLabel")}
+          updatesLink={t("topNavBar.updatesLink")}
+          updatesLinkLabel={t("topNavBar.updatesLinkLabel")}
+          projectsLink={t("topNavBar.projectsLink")}
+          projectsLinkLabel={t("topNavBar.projectsLinkLabel")}
+          navAriaLabel={t("topNavBar.ariaLabel")}
+          buttonAriaLabel={t("topNavBar.buttonAriaLabel")}
+        />
         <div className="layout-container mt-4">
           <Breadcrumb items={breadcrumbItems} />
         </div>


### PR DESCRIPTION
React didn't like the attribute names on our TopNavBar mobile menu SVGs so they've been fixed. Also, the TopNavBar has been made active.
