### PR TITLE
Explore Updates Section

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -564,15 +564,15 @@ export const error404Page = {
 
 export const homePageData = {
   data: {
-    scLabsPagev1ByPath: {
+    sclabsPageV1ByPath: {
       item: {
-        scId: "SCLABS-HOME-PAGE",
+        scId: "PAGES-HOME",
         scPageNameEn: "/en/home",
         scPageNameFr: "/fr/accueil",
         scTitleEn: "Service Canada Labs",
         scTitleFr: "Laboratoires de Service Canada",
-        scShortTitleEn: "Home - Service Canada Labs",
-        scShortTitleFr: "Accueil - Laboratoires de Service Canada",
+        scShortTitleEn: null,
+        scShortTitleFr: null,
         scDescriptionEn: {
           json: [
             {
@@ -609,104 +609,229 @@ export const homePageData = {
         scKeywordsFr: "services numériques",
         scContentType: null,
         scOwner: null,
-        scDateModifiedOverwrite: "2022-12-11",
+        scDateModifiedOverwrite: null,
         scAudience: null,
         scRegion: null,
         scSocialMediaImageEn: {
+          _path: "/content/dam/decd-endc/images/sclabs/homePage_image1.png",
           _publishUrl:
             "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
           width: 2932,
           height: 2078,
         },
         scSocialMediaImageFr: {
+          _path: "/content/dam/decd-endc/images/sclabs/homePage_image1.png",
           _publishUrl:
             "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
           width: 2932,
           height: 2078,
         },
-        scSocialMediaImageAltTextEn: null,
-        scSocialMediaImageAltTextFr: null,
+        scSocialMediaImageAltTextEn: "People adding icons to a mobile screen",
+        scSocialMediaImageAltTextFr:
+          "Personnes ajoutant des icônes à un écran mobile",
         scNoIndex: false,
         scNoFollow: false,
         scFragments: [
           {
+            _model: {
+              title: "SCLabs-Comp-Content-Image-v1",
+            },
+            scId: "COMP-IMAGE-HOME-INTRO",
+            scLabContent: [
+              {
+                scId: "CONTENT-HOME-MAIN",
+                scContentEn: {
+                  json: [
+                    {
+                      nodeType: "header",
+                      style: "h1",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Service Canada Labs",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value:
+                            "Help us make government digital services simple and easy to use. ",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value:
+                            "Service Canada Labs is an experimental corner of Canada.ca where we work on new ways of serving you. Here, you can explore projects in their early stages and help us improve them. We might even stop working on some ideas if we learn they're not adding value and not meeting people's needs. ",
+                        },
+                        {
+                          nodeType: "line-break",
+                          content: [],
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "header",
+                      style: "h2",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Your feedback can shape tomorrow's services",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Here is how you can help:",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "unordered-list",
+                      content: [
+                        {
+                          nodeType: "list-item",
+                          content: [
+                            {
+                              nodeType: "text",
+                              value: "try out our projects",
+                            },
+                          ],
+                        },
+                        {
+                          nodeType: "list-item",
+                          content: [
+                            {
+                              nodeType: "text",
+                              value: "provide your feedback",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                scContentFr: {
+                  json: [
+                    {
+                      nodeType: "header",
+                      style: "h1",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Laboratoires de Service Canada",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value:
+                            "Aidez-nous à rendre les services numériques gouvernementaux plus simples et faciles à utiliser.",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value:
+                            "Les laboratoires de Service Canada sont un espace expérimental de Canada.ca où nous travaillons sur de nouvelles façons de vous servir. Vous pouvez y explorer des projets à leur stade initial et nous aider à les améliorer. Nous pourrions cesser de travailler sur certaines idées si nous découvrons qu'elles n'apportent pas de valeur ajoutée et ne répondent pas aux besoins des gens.",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "header",
+                      style: "h2",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value:
+                            "Vos commentaires peuvent façonner les services de demain",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "paragraph",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Comment participer :",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "unordered-list",
+                      content: [
+                        {
+                          nodeType: "list-item",
+                          content: [
+                            {
+                              nodeType: "text",
+                              value: "essayer nos projets",
+                            },
+                          ],
+                        },
+                        {
+                          nodeType: "list-item",
+                          content: [
+                            {
+                              nodeType: "text",
+                              value: "donner vos commentaires",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+            scLabImage: {
+              scId: "SCLABS-HOMEPAGE-IMAGE",
+              scImageEn: {
+                _publishUrl:
+                  "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+                width: 2932,
+                height: 2078,
+              },
+              scImageFr: {
+                _publishUrl:
+                  "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+                width: 2932,
+                height: 2078,
+              },
+              scImageMobileEn: null,
+              scImageMobileFr: null,
+              scImageAltTextEn: null,
+              scImageAltTextFr: null,
+              scImageCaptionEn: {
+                json: null,
+              },
+              scImageCaptionFr: {
+                json: null,
+              },
+            },
+            scLabLayout: "default",
+          },
+          {
             _path:
-              "/content/dam/decd-endc/content-fragments/sclabs/components/content/home---main-content",
-            scId: "SCLABS-HOMEPAGE-MAIN-CONTENT",
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/home-explore-projects",
+            scId: "CONTENT-HOME-EXPLORE-PROJECTS",
             scContentEn: {
               json: [
-                {
-                  nodeType: "header",
-                  style: "h1",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Service Canada Labs",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Help us make government digital services simple and easy to use.",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Service Canada Labs is an experimental corner of Canada.ca where we work on new ways of serving you. Here, you can explore projects in their early stages and help us improve them. We might even stop working on some ideas if we learn they’re not adding value and not meeting people’s needs. ",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "header",
-                  style: "h2",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Your feedback can shape tomorrow’s services",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Here is how you can help:",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "unordered-list",
-                  content: [
-                    {
-                      nodeType: "list-item",
-                      content: [
-                        {
-                          nodeType: "text",
-                          value: "try out our projects",
-                        },
-                      ],
-                    },
-                    {
-                      nodeType: "list-item",
-                      content: [
-                        {
-                          nodeType: "text",
-                          value: "give your feedback",
-                        },
-                      ],
-                    },
-                  ],
-                },
                 {
                   nodeType: "header",
                   style: "h2",
@@ -723,79 +848,6 @@ export const homePageData = {
               json: [
                 {
                   nodeType: "header",
-                  style: "h1",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Laboratoires de Service Canada",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Aidez-nous à rendre les services numériques gouvernementaux plus simples et faciles à utiliser.",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Les laboratoires de Service Canada sont un espace expérimental de Canada.ca où nous travaillons sur de nouvelles façons de vous servir. Vous pouvez y explorer des projets à leur stade initial et nous aider à les améliorer. Nous pourrions cesser de travailler sur certaines idées si nous découvrons qu'elles n'apportent pas de valeur ajoutée et ne répondent pas aux besoins des gens.",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "header",
-                  style: "h2",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Vos commentaires peuvent façonner les services de demain",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Comment participer :",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "unordered-list",
-                  content: [
-                    {
-                      nodeType: "list-item",
-                      content: [
-                        {
-                          nodeType: "text",
-                          value: "essayer nos projets",
-                        },
-                      ],
-                    },
-                    {
-                      nodeType: "list-item",
-                      content: [
-                        {
-                          nodeType: "text",
-                          value: "donner vos commentaires",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "header",
                   style: "h2",
                   content: [
                     {
@@ -805,31 +857,6 @@ export const homePageData = {
                   ],
                 },
               ],
-            },
-          },
-          {
-            scId: "SCLABS-HOMEPAGE-IMAGE",
-            scImageEn: {
-              _publishUrl:
-                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
-              width: 2932,
-              height: 2078,
-            },
-            scImageFr: {
-              _publishUrl:
-                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
-              width: 2932,
-              height: 2078,
-            },
-            scImageMobileEn: null,
-            scImageMobileFr: null,
-            scImageAltTextEn: null,
-            scImageAltTextFr: null,
-            scImageCaptionEn: {
-              json: null,
-            },
-            scImageCaptionFr: {
-              json: null,
             },
           },
           {
@@ -881,6 +908,114 @@ export const homePageData = {
                     {
                       nodeType: "text",
                       value: ".",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/home-see-all-projects",
+            scId: "CONTENT-HOME-SEE-ALL-PROJECTS",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/en/projects.html",
+                      },
+                      value: "See all projects",
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/fr/projets.html",
+                      },
+                      value: "Consulter tous les projets",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/home-read-updates",
+            scId: "CONTENT-HOME-READ-UPDATES",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Read our latest project updates",
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Consultez les récentes mises à jour de nos projets",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/sclabs/components/content/home-see-all-updates",
+            scId: "CONTENT-HOME-SEE-ALL-UPDATES",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/en/updates.html",
+                      },
+                      value: "See all updates",
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/fr/mises-a-jour.html",
+                      },
+                      value: "Consulter toutes les mises à jour",
                     },
                   ],
                 },
@@ -1299,462 +1434,1755 @@ export const experimentsData = {
 
 export const projectUpdates = {
   data: {
-    scLabsPagev1ByPath: {
-      item: {
-        scId: "WHAT-WE-LEARNED-BUILDING-THE-SERVICE-CANADA-VIRTUAL-ASSISTANT",
-        scPageNameEn:
-          "what-we-learned-building-service-canada-virtual-assistant ",
-        scPageNameFr:
-          "ce-que-nous-avons-appris-en-creant-assistant-virtuel-service-canada",
-        scTitleEn:
-          "What we learned building the Service Canada Virtual Assistant",
-        scTitleFr:
-          "Ce que nous avons appris en créant l'assistant virtuel de Service Canada",
-        scShortTitleEn: null,
-        scShortTitleFr: null,
-        scDescriptionEn: {
-          json: null,
-        },
-        scDescriptionFr: {
-          json: null,
-        },
-        scSubject: null,
-        scKeywordsEn: null,
-        scKeywordsFr: null,
-        scContentType: null,
-        scOwner: null,
-        scDateModifiedOverwrite: "2022-12-18",
-        scAudience: null,
-        scRegion: null,
-        scSocialMediaImageEn: null,
-        scSocialMediaImageFr: null,
-        scSocialMediaImageAltTextEn: null,
-        scSocialMediaImageAltTextFr: null,
-        scNoIndex: false,
-        scNoFollow: false,
-        scFragments: [
-          {
+    sclabsPageV1List: {
+      items: [
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/how-feedback-is-shaping-the-estimator",
+          scId: "HOW-FEEDBACK-SHAPING-ESTIMATOR",
+          scPageNameEn:
+            "/en/projects/oas-benefits-estimator/how-feedback-shaping",
+          scPageNameFr:
+            "/fr/projets/estimateur-prestations-sv/faconner-grace-retroaction",
+          scTitleEn: "How feedback is shaping the estimator",
+          scTitleFr: "Façonner l’estimateur grâce à la rétroaction",
+          scShortTitleEn: null,
+          scShortTitleFr: null,
+          scBreadcrumbParentPages: [
+            {
+              scTitleEn: "Service Canada Labs",
+              scTitleFr: "Laboratoires de Service Canada",
+              scPageNameEn: "/en/home",
+              scPageNameFr: "/fr/accueil",
+            },
+            {
+              scTitleEn: "Old Age Security Benefits Estimator",
+              scTitleFr:
+                "Estimateur des prestations de la Sécurité de la vieillesse",
+              scPageNameEn: "/en/projects/oas-benefits-estimator",
+              scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+            },
+          ],
+          scSubject: [
+            "gc:subjects/gv-government-and-politics/government-services",
+          ],
+          scKeywordsEn: "feedback, benefits, estimator",
+          scKeywordsFr: "rétroaction, prestations, estimateur",
+          scContentType: [
+            "gc:content-types/promotional-material-featured-articles",
+          ],
+          scOwner: ["gc:institutions/service-canada"],
+          scDateModifiedOverwrite: "2023-12-12",
+          scAudience: null,
+          scRegion: null,
+          scSocialMediaImageEn: {
             _path:
-              "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/virtual-assistant/project-updates/va-update-1-content",
-            scId: "VA-UPDATE-1-CONTENT",
-            scContentEn: {
-              json: [
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "# What we learned building the Service Canada Virtual Assistant",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "The Virtual Assistant is a conversational chatbot designed to help Canadians overcome challenges they may face as they apply for and receive benefits.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "## Why was this project important to pursue?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Our goal with the Virtual Assistant was to start with user needs and build a prototype that shows how a user-friendly chatbot experience could be. From there, we can work backwards to identify what else needs to be in place to make it possible.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Many chatbots surface general information, but the Virtual Assistant provides personalized support to those who are signed into their accounts.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "By automating processes that recognize problems with applications, the four chatbot prototypes can help Canadians resolve issues with their EI or OAS applications on their own instead of having to call in for support.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "## Were you able to do research with Canadians? What did you learn?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We were able to do usability testing on one of our early designs with actual employment insurance (EI) recipients. Research participants found the chatbot to be intuitive and easy to use.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We're hoping that future user research will provide us with more feedback on how we could further improve the Virtual Assistant.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "## What has been the outcome of your work so far?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We've paused work on the Virtual Assistant due to lack of funding and resources needed to address significant technical barriers to implementation.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        'For the Virtual Assistant to work, it needs to access data from many different applications. The most effective way for applications to share data is through "application programming interfaces" (APIs), which allow two programs to talk to each other.',
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Unfortunately, the technical systems in our department can't yet provide the APIs we need to build a working version of the Virtual Assistant and no one is available to work on it right now. As a result, the Virtual Assistant is on hold until it is technically possible to launch.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "The Virtual Assistant is a benchmark of the type of service we aim to deliver to clients in the future, and we look forward to making it a reality.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-              ],
-            },
-            scContentFr: {
-              json: [
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "# (FR) What we learned building the Service Canada Virtual Assistant",
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "The Virtual Assistant is a conversational chatbot designed to help Canadians overcome challenges they may face as they apply for and receive benefits.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "## Why was this project important to pursue?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Our goal with the Virtual Assistant was to start with user needs and build a prototype that shows how a user-friendly chatbot experience could be. From there, we can work backwards to identify what else needs to be in place to make it possible.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Many chatbots surface general information, but the Virtual Assistant provides personalized support to those who are signed into their accounts.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "By automating processes that recognize problems with applications, the four chatbot prototypes can help Canadians resolve issues with their EI or OAS applications on their own instead of having to call in for support.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "## Were you able to do research with Canadians? What did you learn?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We were able to do usability testing on one of our early designs with actual employment insurance (EI) recipients. Research participants found the chatbot to be intuitive and easy to use.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We're hoping that future user research will provide us with more feedback on how we could further improve the Virtual Assistant.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "## What has been the outcome of your work so far?",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "We've paused work on the Virtual Assistant due to lack of funding and resources needed to address significant technical barriers to implementation.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        'For the Virtual Assistant to work, it needs to access data from many different applications. The most effective way for applications to share data is through "application programming interfaces" (APIs), which allow two programs to talk to each other.',
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "Unfortunately, the technical systems in our department can't yet provide the APIs we need to build a working version of the Virtual Assistant and no one is available to work on it right now. As a result, the Virtual Assistant is on hold until it is technically possible to launch.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-                {
-                  nodeType: "paragraph",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value:
-                        "The Virtual Assistant is a benchmark of the type of service we aim to deliver to clients in the future, and we look forward to making it a reality.",
-                    },
-                    {
-                      nodeType: "line-break",
-                      content: [],
-                    },
-                  ],
-                },
-              ],
-            },
+              "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+            _publishUrl:
+              "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+            width: 2670,
+            height: 1543,
           },
-          {
-            scId: "EXPLORE-THE-VIRTUAL-ASSISTANT",
-            scTitleEn: "Explore the Virtual Assistant",
-            scTitleFr: "Découvrez l'assistant virtuel",
-            scContentEn: {
-              json: null,
-            },
-            scContentFr: {
-              json: null,
-            },
-            scImageEn: null,
-            scImageFr: null,
-            scImageAltTextEn: null,
-            scImageAltTextFr: null,
-            scLabsButton: [
-              {
-                scId: "EXPLORE-THE-VIRTUAL-ASSISTANT",
-                scTitleEn: "Explore the Virtual Assistant",
-                scTitleFr: "Découvrez l'assistant virtuel",
-                scDestinationURLEn: "/en/projects/virtual-assistant/try-it-out",
-                scDestinationURLFr: "/fr/projets/assistant-virtuel/lessayer",
-                scButtonType: ["gc:custom/decd-endc/button-type/primary"],
+          scSocialMediaImageFr: {
+            _path:
+              "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+            _publishUrl:
+              "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+            width: 2670,
+            height: 1543,
+          },
+          scSocialMediaImageAltTextEn:
+            " Different kinds of feedback being gathered",
+          scSocialMediaImageAltTextFr:
+            " Un rassemblement de différents types de rétroaction",
+          scNoIndex: false,
+          scNoFollow: false,
+          scFragments: [
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-Image-v1",
               },
-            ],
+              scId: "ESTIMATOR-REVIEWING-FEEDBACK",
+              scLabContent: [
+                {
+                  scId: "ESTIMATOR-REVIEWING-FEEDBACK",
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "header",
+                        style: "h1",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "How feedback is shaping the estimator ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "There are many ways to do usability research and use insights to improve client experience. In our beta phase, one of the ways we’re doing this is by collecting feedback from people who try the Old Age Security Benefits Estimator through a survey. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "About 450 visitors have sent responses. This has allowed us to analyze feedback and prioritize changes that are important to our clients. We can see what works and what doesn’t in order to refine the estimator based on their needs. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Reviewing feedback ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Every week, our product team meets for “Feedback Friday” to sort through all the new survey responses. We look at the ratings and comments people shared with us about their experience. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We then organize the survey responses by topic (this is called “affinity mapping”). This gives us a wide view of problem areas and their progression over time. If we see the same comment come up a few times, we know we should take a closer look at what we can do to resolve the issue.",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "header",
+                        style: "h1",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Façonner l’estimateur grâce à la rétroaction ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Il y a de nombreuses façons de mener des recherches sur la convivialité et d’utiliser les résultats pour améliorer l’expérience client. Dans notre phase bêta, nous avons notamment recueilli la rétroaction des personnes qui essaient l’Estimateur des prestations de la Sécurité de la vieillesse au moyen d’un sondage. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Environ 450 visiteurs y ont répondu. Cela nous a permis d’analyser la rétroaction et de prioriser les changements qui sont importants pour nos clients. Nous pouvons voir ce qui fonctionne et ce qui ne fonctionne pas afin d’améliorer l’estimateur en fonction de leurs besoins. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Analyse de la rétroaction ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Chaque semaine, notre équipe de produit se réunit pour le ",
+                          },
+                          {
+                            nodeType: "span",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "« v",
+                              },
+                            ],
+                            data: {
+                              class: "nowrap",
+                            },
+                          },
+                          {
+                            nodeType: "text",
+                            value: "endredi rétroactio",
+                          },
+                          {
+                            nodeType: "span",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "n » ",
+                              },
+                            ],
+                            data: {
+                              class: "nowrap",
+                            },
+                          },
+                          {
+                            nodeType: "text",
+                            value:
+                              "afin de trier toutes les nouvelles réponses au sondage. Nous regardons les évaluations et les commentaires que les gens ont partagés avec nous sur leur expérience. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous organisons ensuite les commentaires par thème (c’est ce qu’on appelle la ",
+                          },
+                          {
+                            nodeType: "span",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "« c",
+                              },
+                            ],
+                            data: {
+                              class: "nowrap",
+                            },
+                          },
+                          {
+                            nodeType: "text",
+                            value: "artographie des affinité",
+                          },
+                          {
+                            nodeType: "span",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "s »",
+                              },
+                            ],
+                            data: {
+                              class: "nowrap",
+                            },
+                          },
+                          {
+                            nodeType: "text",
+                            value:
+                              "). Cela nous permet d’avoir une vue d’ensemble des problèmes et de leur évolution dans le temps. Si le même commentaire revient plusieurs fois, nous savons que nous devrions examiner de plus près ce que nous pouvons faire pour résoudre le problème. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabImage: {
+                scId: "ESTIMATOR-HOW-FEEDBACK-SHAPING",
+                scImageEn: {
+                  _publishUrl:
+                    "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+                  width: 2670,
+                  height: 1543,
+                },
+                scImageFr: {
+                  _publishUrl:
+                    "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+                  width: 2670,
+                  height: 1543,
+                },
+                scImageMobileEn: null,
+                scImageMobileFr: null,
+                scImageAltTextEn: null,
+                scImageAltTextFr: null,
+                scImageCaptionEn: {
+                  json: null,
+                },
+                scImageCaptionFr: {
+                  json: null,
+                },
+              },
+              scLabLayout: "default",
+            },
+            {
+              _model: {
+                title: "SCLabs-Content-v1",
+              },
+              _path:
+                "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/using-feedback",
+              scId: "ESTIMATOR-USING-FEEDBACK",
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Using feedback",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "The estimator has proven to be user-friendly, but that didn't mean it was serving everyone’s needs. In fact, the initial feedback suggested there were specific things we needed to fix. Below, we show how we’ve used feedback with examples inspired by real survey responses. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Utilisation de la rétroaction",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "L’estimateur a bien montré être convivial, mais cela ne veut pas dire qu’il répondait aux besoins de tout le monde. En effet, les commentaires initiaux suggéraient qu’il y avait des choses spécifiques que nous devions corriger. Nous montrons ci-dessous comment nous avons utilisé la rétroaction à l’aide d’exemples inspirés de vraies réponses au sondage. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-v1",
+              },
+              scId: "ESTIMATOR-FUTURE-ESTIMATE-COMMENT-1",
+              scLabContent: [
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "I didn’t like having to change my birth year to get an estimate",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Je n’aimais pas devoir changer mon année de naissance pour avoir une estimation",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We now generate results that give future estimates to those who aren’t eligible yet. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous générons maintenant des résultats qui donnent des estimations futures aux personnes qui ne sont pas encore admissibles. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabLayout: "quote",
+            },
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-v1",
+              },
+              scId: "ESTIMATOR-DEFERRED-AMOUNT-COMMENT-2",
+              scLabContent: [
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "It should show the benefit to deferral if I start to receive after 65",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "On devrait montrer l’avantage d’un report si je commence à recevoir après 65 ans",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We now automatically show a personalized deferred amount to everyone older than 65. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous affichons maintenant automatiquement un montant reporté personnalisé pour toutes les personnes âgées de plus de 65 ans.",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabLayout: "quote",
+            },
+            {
+              _model: {
+                title: "SCLabs-Content-v1",
+              },
+              _path:
+                "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/using-feedback-2",
+              scId: "ESTIMATOR-USING-FEEDBACK-2",
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Having access to feedback and being able to make quick updates has allowed us to add features like these and improve where you told us it matters most. We still have a lot of work to do and can’t address every pain point. But by grouping the feedback by topic, we can identify the most common concerns and prioritize solutions. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Here are examples of comments that represent common feedback themes and how we plan to address them: ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "En ayant accès aux commentaires et en pouvant faire des mises à jour rapides, nous avons pu ajouter des fonctionnalités comme celles-ci et améliorer ce qui était le plus important pour vous. Nous avons encore beaucoup de travail à faire et nous ne pouvons pas résoudre toutes les difficultés. Mais en regroupant les commentaires par thème, nous pouvons identifier les problèmes les plus courants et prioriser les solutions. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Voici des exemples de commentaires qui illustrent des thèmes communs de la rétroaction et comment nous comptons y répondr",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "e :",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-v1",
+              },
+              scId: "ESTIMATOR-INCOME-QUESTION-COMMENT-3",
+              scLabContent: [
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "The income question isn’t clear",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "La question du revenu n’est pas claire",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Our new question will clarify the types of income to include and calculate how much of your work income is exempted. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Notre nouvelle question clarifiera les types de revenus à inclure et calculera la part de votre revenu lié au travail qui est exemptée. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabLayout: "quote",
+            },
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-v1",
+              },
+              scId: "ESTIMATOR-ESTIMATE-COMMENT-4",
+              scLabContent: [
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "I wasn’t given an estimate",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Je n’ai pas reçu d’estimation",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                {
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We’ve already added $0 amounts to estimates to remove ambiguity. We’re also going to be changing the look of the results to make information easier to find. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Nous avons déjà ajouté des montants de ",
+                          },
+                          {
+                            nodeType: "span",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "0 $",
+                              },
+                            ],
+                            data: {
+                              class: "nowrap",
+                            },
+                          },
+                          {
+                            nodeType: "text",
+                            value:
+                              " aux estimations afin de résoudre l’ambiguïté. Nous allons également modifier la présentation des résultats pour que les informations soient plus faciles à trouver. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabLayout: "quote",
+            },
+            {
+              _model: {
+                title: "SCLabs-Content-v1",
+              },
+              _path:
+                "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/measuring-success",
+              scId: "ESTIMATOR-MEASURING-SUCCESS",
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Measuring success ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "After we implement solutions, we’re able to tell if an issue has been resolved through comments and ratings. If we’ve made the right improvements, we stop seeing the issue mentioned, and the ratings start showing positive trends. This allows us to measure the success of our new features and make sure that we’ve improved our clients’ experience. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "For example, we can look at our data from before and after the 2 initial fixes mentioned above. If we compare survey ratings from July to those in October, we see that: ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "20% more people felt that the tool provided the information they needed ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "15% more people said that the tool made them more aware of the benefits available to them ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "To make sure the estimator stays user-friendly as it evolves, we’re also tracking its ease of use, which has stayed roughly the same at 80%. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "By looking at comments and analytics together, we can see how the changes were received and which pain points are resolved. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "What we’re doing next ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We’ll keep monitoring our success indicators as we release updated versions of the estimator. In the meantime, keep sending us comments about your experience. We’re listening! ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Mesure du succès ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Après avoir mis en œuvre des solutions, nous pouvons savoir si un problème a été réglé grâce aux commentaires et aux évaluations. Si nous avons apporté les bonnes améliorations, le problème n’est plus mentionné et les évaluations montrent des tendances positives. Cela nous permet de mesurer le succès de nos nouvelles fonctionnalités et de nous assurer que nous avons amélioré l’expérience de nos clients. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Par exemple, nous pouvons regarder nos données avant et après les ",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "2 premières",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value:
+                          " corrections mentionnées ci-dessus. Si nous comparons les résultats du sondage de juillet à ceux d'octobre, nous constatons que : ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "20 % plus de personnes ont trouvé que l’outil leur avait fourni les informations recherchées; ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "15 % plus de personnes ont indiqué que l'outil les avait renseignés sur les prestations qui leur sont offertes. ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Pour nous assurer que l’estimateur reste convivial à mesure qu’il évolue, nous surveillons également sa facilité d'utilisation, qui est restée stable à environ ",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "80 %",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value: ". ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "En tenant compte à la fois des commentaires et des données analytiques, nous pouvons voir comment les changements ont été reçus et quelles sources de difficultés ont été éliminées. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Ce qui nous attend ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous surveillerons nos indicateurs de succès à mesure que nous publierons de nouvelles versions de l'estimateur. Entre-temps, continuez à nous envoyer des commentaires sur votre expérience. Nous sommes à l'écoute! ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/what-we-learned",
+          scId: "WHAT-WE-LEARNED",
+          scPageNameEn: "/en/projects/oas-benefits-estimator/what-we-learned",
+          scPageNameFr:
+            "/fr/projets/estimateur-prestations-sv/ce-que-nous-avons-appris",
+          scTitleEn:
+            "What we learned on Service Canada Labs before going live on Canada.ca",
+          scTitleFr:
+            "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca",
+          scShortTitleEn: null,
+          scShortTitleFr: null,
+          scBreadcrumbParentPages: [
+            {
+              scTitleEn: "Service Canada Labs",
+              scTitleFr: "Laboratoires de Service Canada",
+              scPageNameEn: "/en/home",
+              scPageNameFr: "/fr/accueil",
+            },
+            {
+              scTitleEn: "Old Age Security Benefits Estimator",
+              scTitleFr:
+                "Estimateur des prestations de la Sécurité de la vieillesse",
+              scPageNameEn: "/en/projects/oas-benefits-estimator",
+              scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+            },
+          ],
+          scSubject: null,
+          scKeywordsEn: null,
+          scKeywordsFr: null,
+          scContentType: [
+            "gc:content-types/promotional-material-featured-articles",
+          ],
+          scOwner: null,
+          scDateModifiedOverwrite: "2023-07-02",
+          scAudience: null,
+          scRegion: null,
+          scSocialMediaImageEn: {
+            _path:
+              "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+            _publishUrl:
+              "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+            width: 2670,
+            height: 1543,
           },
-        ],
-      },
+          scSocialMediaImageFr: {
+            _path:
+              "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+            _publishUrl:
+              "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+            width: 2670,
+            height: 1543,
+          },
+          scSocialMediaImageAltTextEn: "People giving feedback",
+          scSocialMediaImageAltTextFr:
+            "Personnes qui donnent de la rétroaction",
+          scNoIndex: false,
+          scNoFollow: false,
+          scFragments: [
+            {
+              _model: {
+                title: "SCLabs-Comp-Content-Image-v1",
+              },
+              scId: "ESTIMATOR-WHAT-WE-LEARNED",
+              scLabContent: [
+                {
+                  scId: "OAS-BENEFITS-ESTIMATOR-WHAT-WE-LEARNED",
+                  scContentEn: {
+                    json: [
+                      {
+                        nodeType: "header",
+                        style: "h1",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "What we learned on Service Canada Labs before going live on Canada.ca",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "On April 12, 2023, we released an alpha version of the Old Age Security Benefits Estimator to the public. The tool was still in an early development phase, but it was working. We knew the earlier we let everyone use it, the earlier we'd get real feedback.",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Since then, over 4,000 people tried it out, and around 200 provided feedback. Here’s what we learned from the feedback collected in our alpha phase, how it’s helping us improve our tool and what’s next for our beta phase.",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Asking experts what they think ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Ideally, the estimator could save someone a trip or a call to Service Canada. That's why we wanted to know if it answered the most common questions about Old Age Security benefits. To find out, we asked Service Canada employees. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "They confirmed that the estimator was able to give answers to common questions about: ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "who these benefits are for ",
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "how much they can expect to receive ",
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "when they can expect to receive a letter from Service Canada ",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "They told us about other questions they get often, and if they found any missing information. Some even gave us ideas to make this tool even more useful for Canadians. We'll be assessing these during our beta phase and will use this information to continuously improve the estimator. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Using data to improve questions ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We were lucky enough to be able to use data from a similar tool while we were on Service Canada Labs. This helped us gather information about the questions we were asking. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "In alpha, entering an income in the estimator was optional. We wanted to give clients a choice. However, we realized, through our survey, that people were looking for a precise amount in the results. Only providing the maximum income to receive a benefit wasn’t enough. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "The other tool required clients to enter an income. So, we looked at their data. There was nothing to indicate that people didn’t want to do this. The question didn’t stop them from using the tool. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "To give better results, we decided to require income in our beta estimator. This way, we can provide an amount to everyone whose income qualifies, while being confident that the tool is just as easy to use. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Making improvements based on client feedback ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Our main goal for the alpha phase was to get people using the tool and get as much feedback as possible. Anyone who used our tool during our alpha phase could give us their thoughts through an anonymous feedback survey. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We read all the comments and ratings and found it very valuable. Through our survey, we found out that: ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "90% thought the tool was easy to use ",
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "73% were more aware of the benefits available to them ",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Some were satisfied, some had questions, and others wanted to see different features. From the survey responses, we’ve identified the main improvements clients want to see. Many wanted: ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "the ability to get an estimate from a younger age ",
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "more clarity about which types of income affect benefits ",
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "to have more information about their partner’s results ",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We’ve already started working on these features and other adjustments. For example, in the beta version now on Canada.ca, we’ve added more detailed and visible results for partners. We’re looking forward to having this improvement and other tweaks make the tool better for Canadians. ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Share your feedback ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "We’re still collecting and addressing feedback! The estimator is still in active development and will be evolving to better meet your needs throughout the beta. Expect to see some changes! ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  scContentFr: {
+                    json: [
+                      {
+                        nodeType: "header",
+                        style: "h1",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Le 12 avril 2023, nous avons publié une version alpha de l’Estimateur des prestations de la Sécurité de la vieillesse. L’outil était encore dans une phase de développement préliminaire, mais il fonctionnait. Nous savions que nous pourrions obtenir de la véritable rétroaction plus tôt si nous permettions à tout le monde de l’utiliser. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Depuis, plus de 4 000 personnes l’ont essayé et environ 200 ont donné leur rétroaction. Voici ce que nous avons appris des avis recueillis au cours de notre phase alpha, comment ils nous aident à améliorer notre outil et ce qui nous attend pour notre phase bêta. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Demander aux experts ce qu’ils en pensent ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Idéalement, l’estimateur pourrait épargner à quelqu’un un voyage ou un appel à Service Canada. Voilà pourquoi nous voulions savoir s’il répondait aux questions les plus fréquentes sur les prestations de la Sécurité de la vieillesse. Pour le savoir, nous avons consulté les employés de Service Canada. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Ils ont confirmé que l’estimateur répondait aux questions les plus courantes concernant : ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value: "à qui s’adressent ces prestations; ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "le montant qu’ils peuvent s’attendre à recevoir; ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "quand ils peuvent s’attendre à recevoir une lettre de Service Canada. ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Ils nous ont fait part d’autres questions qui leur sont souvent posées et nous ont dit s’ils avaient trouvé des informations manquantes. Certains nous ont même donné des idées pour rendre cet outil encore plus utile pour la population canadienne. Nous évaluerons ces idées au cours de notre phase bêta et nous utiliserons ces informations pour continuer à améliorer l’estimateur. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Utiliser des données pour améliorer les questions ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous avions la chance de pouvoir utiliser les données d’un outil similaire lorsque nous étions sur les laboratoires de Service Canada. Cela nous a permis de recueillir des informations sur nos questions. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Dans la version alpha, il était facultatif de saisir un revenu dans I’estimateur. Nous voulions donner le choix aux clients. Cependant, nous nous sommes rendu compte, grâce à notre sondage, que les gens recherchaient un montant précis dans les résultats. Indiquer le revenu maximum pour recevoir une prestation n’était pas suffisant. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "L’autre outil exigeait que les clients entrent un revenu. Nous avons donc examiné leurs données. Rien n’indiquait que les gens ne voulaient pas remplir ce champ. La question ne les empêchait pas d’utiliser l’outil. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Pour fournir de meilleurs résultats, nous avons décidé d’exiger un revenu dans notre estimateur bêta. De cette manière, nous pouvons fournir un montant à toutes les personnes dont le revenu est admissible, tout en étant assurés que l’outil est tout aussi facile à utiliser. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Apporter des améliorations à partir de la rétroaction des clients ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Notre objectif principal pour la phase alpha était d’amener les gens à utiliser l’outil et de recevoir le plus de rétroaction possible. Toute personne ayant utilisé notre outil pendant la phase alpha pouvait nous faire part de ses impressions en répondant à un sondage anonyme. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous avons lu tous les commentaires et évaluations et les avons trouvés très utiles. Notre sondage nous a permis de constater que : ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "90 % ont trouvé que l’outil était facile à utiliser; ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "73 % étaient plus conscients des prestations qui leur étaient offertes. ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Certains étaient satisfaits, certains avaient des questions et d’autres voulaient voir d’autres fonctionnalités. À partir des réponses au sondage, nous avons identifié les principales améliorations souhaitées par les clients. De nombreuses personnes voulaient : ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "unordered-list",
+                        content: [
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "pouvoir obtenir une estimation d’un plus jeune âge;   ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "plus de clarté sur les types de revenus qui affectent les prestations;  ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                          {
+                            nodeType: "list-item",
+                            content: [
+                              {
+                                nodeType: "text",
+                                value:
+                                  "avoir plus d’information sur les résultats de leur partenaire.   ",
+                              },
+                              {
+                                nodeType: "line-break",
+                                content: [],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous avons déjà commencé à travailler sur ces fonctionnalités et sur d’autres ajustements. Par exemple, dans la version bêta actuellement disponible sur Canada.ca, nous avons ajouté des résultats plus détaillés et plus visibles pour les partenaires. Nous avons hâte de voir cette amélioration et d’autres mises à jour améliorer l’outil pour tous. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "header",
+                        style: "h2",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "Partagez votre avis ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "paragraph",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "Nous continuons à recueillir et à intégrer la rétroaction! L’estimateur est encore en développement actif et évoluera pour mieux répondre à vos besoins tout au long de la version bêta. Attendez-vous à voir des changements! ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+              scLabImage: {
+                scId: "WHAT-WE-LEARNED",
+                scImageEn: {
+                  _publishUrl:
+                    "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+                  width: 2670,
+                  height: 1543,
+                },
+                scImageFr: {
+                  _publishUrl:
+                    "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+                  width: 2670,
+                  height: 1543,
+                },
+                scImageMobileEn: null,
+                scImageMobileFr: null,
+                scImageAltTextEn: null,
+                scImageAltTextFr: null,
+                scImageCaptionEn: {
+                  json: null,
+                },
+                scImageCaptionFr: {
+                  json: null,
+                },
+              },
+              scLabLayout: "default",
+            },
+            {
+              _model: {
+                title: "SCLabs-Button-v1",
+              },
+              scId: "GIVE-FEEDBACK-OAS-ESTIMATOR",
+              scTitleEn: "Give feedback",
+              scTitleFr: "Fournir des commentaires",
+              scDestinationURLEn:
+                "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=eng",
+              scDestinationURLFr:
+                "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=fra",
+              scButtonType: ["gc:custom/decd-endc/button-type/secondary"],
+            },
+          ],
+        },
+      ],
     },
   },
 };
@@ -1763,6 +3191,13 @@ export const dictionaryData = {
   data: {
     dictionaryV1List: {
       items: [
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sch/dictionary/opens-in-a-new-tab",
+          scId: "opens-in-a-new-tab",
+          scTermEn: "(Opens in a new tab)",
+          scTermFr: "(S'ouvre dans un nouvel onglet)",
+        },
         {
           _path:
             "/content/dam/decd-endc/content-fragments/sclabs/dictionary/all",
@@ -1783,6 +3218,27 @@ export const dictionaryData = {
           scId: "FILTER-BY",
           scTermEn: "Filter by:",
           scTermFr: "Filtrer par :",
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/filter-by-project",
+          scId: "DICTIONARY-FILTER-BY-PROJECT",
+          scTermEn: "Filter by project",
+          scTermFr: "Filtrer par projet",
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/filter-by-project-status",
+          scId: "DICTIONARY-FILTER-BY-PROJECT-STATUS",
+          scTermEn: "Filter by project status",
+          scTermFr: "Filtrer par état du projet",
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/last-updated",
+          scId: "LAST-UPDATED",
+          scTermEn: "Last updated:",
+          scTermFr: "Dernière mise à jour :",
         },
         {
           _path:
@@ -1809,8 +3265,15 @@ export const dictionaryData = {
           _path:
             "/content/dam/decd-endc/content-fragments/sclabs/dictionary/paused",
           scId: "PAUSED",
-          scTermEn: "Paused",
+          scTermEn: "Paused:",
           scTermFr: "Interrompu :",
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/posted-on",
+          scId: "POSTED-ON",
+          scTermEn: "Posted on:",
+          scTermFr: "Publié le :",
         },
         {
           _path:
@@ -1821,10 +3284,24 @@ export const dictionaryData = {
         },
         {
           _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/project-updates",
+          scId: "PROJECT-UPDATES",
+          scTermEn: "Project updates",
+          scTermFr: "Mises à jour du projet",
+        },
+        {
+          _path:
             "/content/dam/decd-endc/content-fragments/sclabs/dictionary/required-information",
           scId: "REQUIRED-INFORMATION",
           scTermEn: "Required information",
           scTermFr: "Renseignements obligatoires",
+        },
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/dictionary/see-all-updates-project",
+          scId: "DICTIONARY-SEE-ALL-UPDATES-PROJECT",
+          scTermEn: "See all updates about this project",
+          scTermFr: "Consulter toutes les mises à jour de ce projet",
         },
         {
           _path:
@@ -1837,7 +3314,7 @@ export const dictionaryData = {
           _path:
             "/content/dam/decd-endc/content-fragments/sclabs/dictionary/summary",
           scId: "SUMMARY",
-          scTermEn: "Summary",
+          scTermEn: "Summary:",
           scTermFr: "Résumé :",
         },
         {

--- a/__tests__/pages/home.test.js
+++ b/__tests__/pages/home.test.js
@@ -5,13 +5,15 @@ import { render, screen } from "@testing-library/react";
 import Home from "../../pages/home";
 import { homePageData } from "../../__mocks__/mockStore";
 import { experimentsData } from "../../__mocks__/mockStore";
+import { dictionaryData } from "../../__mocks__/mockStore";
 
 describe("Home", () => {
   it("renders without crashing", () => {
     render(
       <Home
-        pageData={homePageData.data.scLabsPagev1ByPath}
+        pageData={homePageData.data.sclabsPageV1ByPath}
         experimentsData={experimentsData.data.scLabsPagev1List.items}
+        dictionary={dictionaryData.data.dictionaryV1List}
       />
     );
     expect(

--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -1,10 +1,7 @@
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
 
-export function DateModified({
-  date = process.env.NEXT_PUBLIC_BUILD_DATE,
-  ...props
-}) {
+export function DateModified(props) {
   const { t } = useTranslation("common");
   // TeamCity build dates are received in the format yyyyMMdd
   let dateFormatted = "NA";
@@ -27,6 +24,10 @@ export function DateModified({
     </dl>
   );
 }
+
+DateModified.defaultProps = {
+  date: process.env.NEXT_PUBLIC_BUILD_DATE,
+};
 
 DateModified.propTypes = {
   // Date string in format yyyyMMdd

--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -1,7 +1,10 @@
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
 
-export function DateModified(props) {
+export function DateModified({
+  date = process.env.NEXT_PUBLIC_BUILD_DATE,
+  ...props
+}) {
   const { t } = useTranslation("common");
   // TeamCity build dates are received in the format yyyyMMdd
   let dateFormatted = "NA";
@@ -24,10 +27,6 @@ export function DateModified(props) {
     </dl>
   );
 }
-
-DateModified.defaultProps = {
-  date: process.env.NEXT_PUBLIC_BUILD_DATE,
-};
 
 DateModified.propTypes = {
   // Date string in format yyyyMMdd

--- a/components/atoms/Link.js
+++ b/components/atoms/Link.js
@@ -48,7 +48,7 @@ export function Link({
       break;
     default:
       basicStyle =
-        "underline text-multi-blue-blue70b font-body text-browserh5 leading-33px hover:text-multi-blue-blue50b";
+        "underline underline-offset-4 text-multi-blue-blue70b font-body text-browserh5 leading-33px hover:text-multi-blue-blue50b";
       break;
   }
 
@@ -66,23 +66,9 @@ export function Link({
       target={target}
       aria-label={ariaLabel || text}
       role="link"
+      className={`${basicStyle}`}
     >
-      <a
-        href={href}
-        locale={locale}
-        onClick={onClick ? onClick : undefined}
-        id={id}
-        className={`${basicStyle}`}
-        data-gc-analytics-customclick={dataGcAnalyticsCustomClick}
-        onKeyDown={onKeyDown}
-      >
-        {/* <!-- English Text: English --> */}
-        <span className={abbr ? "language-toggle-text" : ""}>{text}</span>
-        {/* <!-- English Text: title="English", en --> */}
-        <abbr className="language-toggle-abbr" title={text}>
-          {abbr}
-        </abbr>
-      </a>
+      {text}
     </Component>
   ) : (
     <a
@@ -97,12 +83,7 @@ export function Link({
       onClick={onClick ? onClick : undefined}
       data-gc-analytics-customclick={dataGcAnalyticsCustomClick}
     >
-      {/* <!-- English Text: English --> */}
-      <span className={abbr ? "language-toggle-text" : ""}>{text}</span>
-      {/* <!-- English Text: title="English", en --> */}
-      <abbr className="language-toggle-abbr" title={text}>
-        {abbr}
-      </abbr>
+      {text}
     </a>
   );
 }

--- a/components/atoms/Link.js
+++ b/components/atoms/Link.js
@@ -3,10 +3,25 @@ import PropTypes from "prop-types";
 
 // Use this component for Footer link and use Next.js <Link>
 // for all links within the site
-export function Link({ target = "_self", href = "#", ...props }) {
+export function Link({
+  href = "#",
+  target = "_self",
+  ariaLabel,
+  component = "a",
+  linkStyle,
+  disabled,
+  lang,
+  locale,
+  onClick,
+  id,
+  dataGcAnalyticsCustomClick,
+  text,
+  abbr,
+  ...rest
+}) {
   //Styling for links based on Figma Design
   let basicStyle = "";
-  switch (props.linkStyle) {
+  switch (linkStyle) {
     case "basicStyleWithEmphasis":
       basicStyle =
         "underline text-multi-blue-blue70b font-body text-browserh5 font-bold text-mobileh5 leading-33px hover:text-multi-blue-blue50b";
@@ -37,7 +52,7 @@ export function Link({ target = "_self", href = "#", ...props }) {
       break;
   }
 
-  const Component = props.component || "a";
+  const Component = component || "a";
 
   function onKeyDown() {
     true;
@@ -45,52 +60,48 @@ export function Link({ target = "_self", href = "#", ...props }) {
 
   return Component !== "a" ? (
     <Component
-      href={props.href}
-      disabled={props.disabled}
-      lang={props.lang}
-      target={props.target}
-      aria-label={props.ariaLabel || props.text}
+      href={href}
+      disabled={disabled}
+      lang={lang}
+      target={target}
+      aria-label={ariaLabel || text}
       role="link"
     >
       <a
-        href={props.href}
-        locale={props.locale}
-        onClick={props.onClick ? props.onClick : undefined}
-        id={props.id}
+        href={href}
+        locale={locale}
+        onClick={onClick ? onClick : undefined}
+        id={id}
         className={`${basicStyle}`}
-        data-gc-analytics-customclick={props.dataGcAnalyticsCustomClick}
+        data-gc-analytics-customclick={dataGcAnalyticsCustomClick}
         onKeyDown={onKeyDown}
       >
         {/* <!-- English Text: English --> */}
-        <span className={props.abbr ? "language-toggle-text" : ""}>
-          {props.text}
-        </span>
+        <span className={abbr ? "language-toggle-text" : ""}>{text}</span>
         {/* <!-- English Text: title="English", en --> */}
-        <abbr className="language-toggle-abbr" title={props.text}>
-          {props.abbr}
+        <abbr className="language-toggle-abbr" title={text}>
+          {abbr}
         </abbr>
       </a>
     </Component>
   ) : (
     <a
-      href={props.href}
+      href={href}
       className={`${basicStyle}`}
-      id={props.id}
-      disabled={props.disabled}
-      lang={props.lang}
-      target={props.target}
-      aria-label={props.ariaLabel || props.text}
-      locale={props.locale}
-      onClick={props.onClick ? props.onClick : undefined}
-      data-gc-analytics-customclick={props.dataGcAnalyticsCustomClick}
+      id={id}
+      disabled={disabled}
+      lang={lang}
+      target={target}
+      aria-label={ariaLabel || text}
+      locale={locale}
+      onClick={onClick ? onClick : undefined}
+      data-gc-analytics-customclick={dataGcAnalyticsCustomClick}
     >
       {/* <!-- English Text: English --> */}
-      <span className={props.abbr ? "language-toggle-text" : ""}>
-        {props.text}
-      </span>
+      <span className={abbr ? "language-toggle-text" : ""}>{text}</span>
       {/* <!-- English Text: title="English", en --> */}
-      <abbr className="language-toggle-abbr" title={props.text}>
-        {props.abbr}
+      <abbr className="language-toggle-abbr" title={text}>
+        {abbr}
       </abbr>
     </a>
   );

--- a/components/atoms/Link.js
+++ b/components/atoms/Link.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 // Use this component for Footer link and use Next.js <Link>
 // for all links within the site
-export function Link(props) {
+export function Link({ target = "_self", href = "#", ...props }) {
   //Styling for links based on Figma Design
   let basicStyle = "";
   switch (props.linkStyle) {
@@ -95,11 +95,6 @@ export function Link(props) {
     </a>
   );
 }
-
-Link.defaultProps = {
-  target: "_self",
-  href: "#",
-};
 
 Link.propTypes = {
   /**

--- a/components/fragment_renderer/FragmentRender.js
+++ b/components/fragment_renderer/FragmentRender.js
@@ -17,7 +17,7 @@ const FRAGMENTS = {
   "SCLabs-Image-v1": ImageWithCollapse,
 };
 
-const mapFragmentsToProps = (fragmentData, fragmentName, locale) => {
+const mapFragmentsToProps = (fragmentData, fragmentName, locale, excludeH1) => {
   switch (fragmentName) {
     case "SCLabs-Feature-v1":
       return {
@@ -63,6 +63,7 @@ const mapFragmentsToProps = (fragmentData, fragmentName, locale) => {
             ? fragmentData.scLabContent[0].scContentEn.json
             : fragmentData.scLabContent[0].scContentFr.json,
         layout: fragmentData.scLabLayout,
+        excludeH1: excludeH1,
       };
 
     case "SCLabs-Comp-Content-v1":
@@ -146,7 +147,8 @@ export default function FragmentRender(props) {
         {...mapFragmentsToProps(
           fragmentData,
           fragmentData?._model.title,
-          props.locale
+          props.locale,
+          props.excludeH1
         )}
       />
     );

--- a/components/fragment_renderer/fragment_components/BasicTextWithImage.js
+++ b/components/fragment_renderer/fragment_components/BasicTextWithImage.js
@@ -1,7 +1,14 @@
 import Image from "next/image";
 import TextRender from "../../text_node_renderer/TextRender";
 
-export default function BasicTextWithImage({ src, alt, width, height, data }) {
+export default function BasicTextWithImage({
+  src,
+  alt,
+  width,
+  height,
+  data,
+  excludeH1,
+}) {
   return (
     <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
       <div className="hidden lg:grid col-start-8 col-span-5 row-start-1 row-span-2">
@@ -19,7 +26,7 @@ export default function BasicTextWithImage({ src, alt, width, height, data }) {
         </div>
       </div>
       <div className="col-span-12 lg:col-span-7">
-        <TextRender data={data} excludeH1={true} />
+        <TextRender data={data} excludeH1={excludeH1} />
       </div>
     </div>
   );

--- a/components/fragment_renderer/fragment_components/TextWithImage.js
+++ b/components/fragment_renderer/fragment_components/TextWithImage.js
@@ -8,6 +8,7 @@ export default function TextWithImage({
   height,
   data,
   layout,
+  excludeH1,
 }) {
   switch (layout) {
     case "default":
@@ -18,6 +19,7 @@ export default function TextWithImage({
           width={width}
           height={height}
           data={data}
+          excludeH1={excludeH1}
         />
       );
     case "image-vertical-line-content":
@@ -28,6 +30,7 @@ export default function TextWithImage({
           width={width}
           height={height}
           data={data}
+          excludeH1={excludeH1}
         />
       );
     default:

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -28,7 +28,7 @@ export const Card = (props) => {
         data-cy={props.dataCy}
       >
         {props.showImage ? (
-          <div className="sm:h-80 flex justify-center">
+          <div className="h-[208px] flex justify-center">
             <Image
               src={props.imgSrc}
               alt={props.imgAlt}

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -22,7 +22,7 @@ export const Card = (props) => {
     <Link href={props.href}>
       <div
         className={`h-full group card-shadow border border-custom-gray-border rounded-md pb-4 hover:cursor-pointer ${
-          "border-" + tagColour
+          "border-" + tagColour + ` ${props.customStyling}`
         }`}
         data-testid={props.dataTestId}
         data-cy={props.dataCy}
@@ -76,9 +76,13 @@ export const Card = (props) => {
         ) : (
           ""
         )}
-        <p className="text-custom-gray-text mx-6 leading-30px text-lg">
-          {props.description}
-        </p>
+        {props.htmlDesc ? (
+          props.description
+        ) : (
+          <p className="text-custom-gray-text mx-6 leading-30px text-lg">
+            {props.description}
+          </p>
+        )}
         {props.showButton ? (
           <ActionButton
             href={props.btnHref}
@@ -130,6 +134,11 @@ Card.propTypes = {
    * the test id for cypress test
    */
   dataCy: PropTypes.string,
+
+  /**
+   * Boolean value to allow passing of html for description
+   */
+  htmlDesc: PropTypes.bool,
 
   /**
    * Boolean value to show or hide image

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -77,7 +77,7 @@ export const Card = (props) => {
           ""
         )}
         {props.htmlDesc ? (
-          props.description
+          props.htmlDesc
         ) : (
           <p className="text-custom-gray-text mx-6 leading-30px text-lg">
             {props.description}
@@ -123,7 +123,7 @@ Card.propTypes = {
   /**
    * Description of the experiment card.
    */
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
 
   /**
    * the test id for unit tests
@@ -138,7 +138,7 @@ Card.propTypes = {
   /**
    * Boolean value to allow passing of html for description
    */
-  htmlDesc: PropTypes.bool,
+  htmlDesc: PropTypes.object,
 
   /**
    * Boolean value to show or hide image

--- a/components/organisms/ExploreUpdates.js
+++ b/components/organisms/ExploreUpdates.js
@@ -1,0 +1,28 @@
+import { Link } from "../atoms/Link";
+
+export function ExploreUpdates({
+  heading = "Read our latest project updates",
+  updatesData,
+  href = "/somelink",
+  linkLabel = "More updates",
+  locale = "en",
+}) {
+  return (
+    <div className="mt-14 bg-custom-blue-updates-blue">
+      <div className="layout-container py-28">
+        <h2 className="mt-0">{heading}</h2>
+        <ul className="mt-8 flex flex-col">
+          <li>List item</li>
+        </ul>
+        <div className="mt-5 flex justify-end">
+          <Link
+            id="seeAllUpdatesLink"
+            href="/projects"
+            lang={locale}
+            text="See all updates"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/organisms/ExploreUpdates.js
+++ b/components/organisms/ExploreUpdates.js
@@ -13,11 +13,10 @@ export function ExploreUpdates({
     return (
       <li key={update.scId} className="bg-white list-none my-3">
         <Card
-          htmlDesc
           customStyling="md:h-[190px] pb-6 flex flex-col justify-between"
           title={locale === "en" ? update.scTitleEn : update.scTitleFr}
           href={locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-          description={
+          htmlDesc={
             <div className="flex flex-col">
               <span className="flex flex-row pl-6">
                 <p className="text-multi-neutrals-grey100 font-semibold">

--- a/components/organisms/ExploreUpdates.js
+++ b/components/organisms/ExploreUpdates.js
@@ -1,4 +1,5 @@
-import { Link } from "../atoms/Link";
+import Link from "next/link";
+import { Link as LinkWrapper } from "../atoms/Link";
 import Card from "../molecules/Card";
 
 export function ExploreUpdates({
@@ -47,7 +48,8 @@ export function ExploreUpdates({
           <ul className="grid col-span-12 xl:col-span-8">{updatesCards}</ul>
           <div className="grid col-span-12 xl:col-span-8 mt-4">
             <div className="flex justify-end">
-              <Link
+              <LinkWrapper
+                component={Link}
                 id="seeAllUpdatesLink"
                 href={href}
                 lang={locale}

--- a/components/organisms/ExploreUpdates.js
+++ b/components/organisms/ExploreUpdates.js
@@ -1,26 +1,61 @@
 import { Link } from "../atoms/Link";
+import Card from "../molecules/Card";
 
 export function ExploreUpdates({
-  heading = "Read our latest project updates",
+  heading,
   updatesData,
-  href = "/somelink",
-  linkLabel = "More updates",
-  locale = "en",
+  href,
+  linkLabel,
+  locale,
+  dictionary,
 }) {
+  const updatesCards = updatesData.map((update) => {
+    return (
+      <li key={update.scId} className="bg-white list-none my-3">
+        <Card
+          htmlDesc
+          customStyling="md:h-[190px] pb-6 flex flex-col justify-between"
+          title={locale === "en" ? update.scTitleEn : update.scTitleFr}
+          href={locale === "en" ? update.scPageNameEn : update.scPageNameFr}
+          description={
+            <div className="flex flex-col">
+              <span className="flex flex-row pl-6">
+                <p className="text-multi-neutrals-grey100 font-semibold">
+                  {locale === "en" ? "Project:" : "Projet :"}
+                </p>
+                <p className="mt-0 pl-1">{`${update.scDateModifiedOverwrite}`}</p>
+              </span>
+              <span className="flex flex-row pl-6">
+                <p className="text-multi-neutrals-grey100 font-semibold">
+                  {locale === "en"
+                    ? dictionary.items[11].scTermEn
+                    : dictionary.items[11].scTermFr}
+                </p>
+                <p className="mt-0 pl-1">{`${update.scDateModifiedOverwrite}`}</p>
+              </span>
+            </div>
+          }
+        />
+      </li>
+    );
+  });
+
   return (
     <div className="mt-14 bg-custom-blue-updates-blue">
       <div className="layout-container py-28">
-        <h2 className="mt-0">{heading}</h2>
-        <ul className="mt-8 flex flex-col">
-          <li>List item</li>
-        </ul>
-        <div className="mt-5 flex justify-end">
-          <Link
-            id="seeAllUpdatesLink"
-            href="/projects"
-            lang={locale}
-            text="See all updates"
-          />
+        <div className="grid grid-cols-12">
+          <h2 className="grid col-span-12 xl:col-span-8 mt-0">{heading}</h2>
+          <ul className="grid col-span-12 xl:col-span-8">{updatesCards}</ul>
+          <div className="grid col-span-12 xl:col-span-8 mt-4">
+            <div className="flex justify-end">
+              <Link
+                id="seeAllUpdatesLink"
+                href={href}
+                lang={locale}
+                text={linkLabel}
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/components/organisms/ExploreUpdates.stories.js
+++ b/components/organisms/ExploreUpdates.stories.js
@@ -1,0 +1,258 @@
+import React from "react";
+import { ExploreUpdates } from "./ExploreUpdates";
+
+export default {
+  title: "Components/organisms/ExploreUpdates",
+  component: ExploreUpdates,
+};
+
+const Template = (args) => <ExploreUpdates {...args}></ExploreUpdates>;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  locale: "en",
+  heading: "Explore more updates",
+  updatesData: [
+    {
+      _path:
+        "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/how-feedback-is-shaping-the-estimator",
+      scId: "HOW-FEEDBACK-SHAPING-ESTIMATOR",
+      scPageNameEn: "/en/projects/oas-benefits-estimator/how-feedback-shaping",
+      scPageNameFr:
+        "/fr/projets/estimateur-prestations-sv/faconner-grace-retroaction",
+      scTitleEn: "How feedback is shaping the estimator",
+      scTitleFr: "Façonner l’estimateur grâce à la rétroaction",
+      scBreadcrumbParentPages: [
+        {
+          scTitleEn: "Service Canada Labs",
+          scTitleFr: "Laboratoires de Service Canada",
+          scPageNameEn: "/en/home",
+          scPageNameFr: "/fr/accueil",
+        },
+        {
+          scTitleEn: "Old Age Security Benefits Estimator",
+          scTitleFr:
+            "Estimateur des prestations de la Sécurité de la vieillesse",
+          scPageNameEn: "/en/projects/oas-benefits-estimator",
+          scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+        },
+      ],
+      scSubject: ["gc:subjects/gv-government-and-politics/government-services"],
+      scKeywordsEn: "feedback, benefits, estimator",
+      scKeywordsFr: "rétroaction, prestations, estimateur",
+      scContentType: [
+        "gc:content-types/promotional-material-featured-articles",
+      ],
+      scOwner: ["gc:institutions/service-canada"],
+      scDateModifiedOverwrite: "2023-12-12",
+      scSocialMediaImageEn: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageFr: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageAltTextEn:
+        " Different kinds of feedback being gathered",
+      scSocialMediaImageAltTextFr:
+        " Un rassemblement de différents types de rétroaction",
+    },
+    {
+      _path:
+        "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/what-we-learned",
+      scId: "WHAT-WE-LEARNED",
+      scPageNameEn: "/en/projects/oas-benefits-estimator/what-we-learned",
+      scPageNameFr:
+        "/fr/projets/estimateur-prestations-sv/ce-que-nous-avons-appris",
+      scTitleEn:
+        "What we learned on Service Canada Labs before going live on Canada.ca",
+      scTitleFr:
+        "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca",
+      scBreadcrumbParentPages: [
+        {
+          scTitleEn: "Service Canada Labs",
+          scTitleFr: "Laboratoires de Service Canada",
+          scPageNameEn: "/en/home",
+          scPageNameFr: "/fr/accueil",
+        },
+        {
+          scTitleEn: "Old Age Security Benefits Estimator",
+          scTitleFr:
+            "Estimateur des prestations de la Sécurité de la vieillesse",
+          scPageNameEn: "/en/projects/oas-benefits-estimator",
+          scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+        },
+      ],
+      scContentType: [
+        "gc:content-types/promotional-material-featured-articles",
+      ],
+      scDateModifiedOverwrite: "2023-07-02",
+      scSocialMediaImageEn: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageFr: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageAltTextEn: "People giving feedback",
+      scSocialMediaImageAltTextFr: "Personnes qui donnent de la rétroaction",
+    },
+  ],
+  dictionary: {
+    items: [
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sch/dictionary/opens-in-a-new-tab",
+        scId: "opens-in-a-new-tab",
+        scTermEn: "(Opens in a new tab)",
+        scTermFr: "(S'ouvre dans un nouvel onglet)",
+      },
+      {
+        _path: "/content/dam/decd-endc/content-fragments/sclabs/dictionary/all",
+        scId: "ALL",
+        scTermEn: "All",
+        scTermFr: "Tous",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/ended",
+        scId: "ENDED",
+        scTermEn: "Ended",
+        scTermFr: "Fin",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/filter-by",
+        scId: "FILTER-BY",
+        scTermEn: "Filter by:",
+        scTermFr: "Filtrer par :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/filter-by-project",
+        scId: "DICTIONARY-FILTER-BY-PROJECT",
+        scTermEn: "Filter by project",
+        scTermFr: "Filtrer par projet",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/filter-by-project-status",
+        scId: "DICTIONARY-FILTER-BY-PROJECT-STATUS",
+        scTermEn: "Filter by project status",
+        scTermFr: "Filtrer par état du projet",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/last-updated",
+        scId: "LAST-UPDATED",
+        scTermEn: "Last updated:",
+        scTermFr: "Dernière mise à jour :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/on-this-page",
+        scId: "ON-THIS-PAGE",
+        scTermEn: "On this page",
+        scTermFr: "Sur cette page",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/optional-information",
+        scId: "OPTIONAL-INFORMATION",
+        scTermEn: "Optional information",
+        scTermFr: "Renseignements optionnels",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/past-projects",
+        scId: "PAST-PROJECTS",
+        scTermEn: "Past projects",
+        scTermFr: "Projets antérieurs",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/paused",
+        scId: "PAUSED",
+        scTermEn: "Paused:",
+        scTermFr: "Interrompu :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/posted-on",
+        scId: "POSTED-ON",
+        scTermEn: "Posted on:",
+        scTermFr: "Publié le :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/project-stage",
+        scId: "PROJECT-STAGE",
+        scTermEn: "Project stage:",
+        scTermFr: "Phase du projet :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/project-updates",
+        scId: "PROJECT-UPDATES",
+        scTermEn: "Project updates",
+        scTermFr: "Mises à jour du projet",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/required-information",
+        scId: "REQUIRED-INFORMATION",
+        scTermEn: "Required information",
+        scTermFr: "Renseignements obligatoires",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/see-all-updates-project",
+        scId: "DICTIONARY-SEE-ALL-UPDATES-PROJECT",
+        scTermEn: "See all updates about this project",
+        scTermFr: "Consulter toutes les mises à jour de ce projet",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/started",
+        scId: "STARTED",
+        scTermEn: "Started:",
+        scTermFr: "Début :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/summary",
+        scId: "SUMMARY",
+        scTermEn: "Summary:",
+        scTermFr: "Résumé :",
+      },
+      {
+        _path:
+          "/content/dam/decd-endc/content-fragments/sclabs/dictionary/upcoming-projects",
+        scId: "UPCOMING-PROJECTS",
+        scTermEn: "Upcoming projects",
+        scTermFr: "Projets à venir",
+      },
+    ],
+  },
+  href: "#",
+  linkLabel: "See more updates",
+};

--- a/components/organisms/ExploreUpdates.test.js
+++ b/components/organisms/ExploreUpdates.test.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Default } from "./ExploreUpdates.stories.js";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ExploreUpdates } from "./ExploreUpdates";
+
+expect.extend(toHaveNoViolations);
+
+describe("ExploreUpdates", () => {
+  test("renders properly with default props", async () => {
+    const { container } = render(<ExploreUpdates {...Default.args} />);
+    expect(screen.getByText("Explore more updates")).toBeInTheDocument();
+    expect(
+      screen.getByText("How feedback is shaping the estimator")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "What we learned on Service Canada Labs before going live on Canada.ca"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Project:")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Posted on:")[0]).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -38,7 +38,9 @@ export const Footer = ({
   preFooterTitle,
   preFooterLink,
   preFooterLinkText,
+  contactLink = "https://www.canada.ca/en/contact.html",
   lang,
+  withMainBand = true,
 }) => {
   return (
     <footer id={id} data-testid="footer">
@@ -81,11 +83,6 @@ export const Footer = ({
       />
     </footer>
   );
-};
-
-Footer.defaultProps = {
-  contactLink: "https://www.canada.ca/en/contact.html",
-  withMainBand: true,
 };
 
 Footer.propTypes = {

--- a/components/organisms/Layout.stories.js
+++ b/components/organisms/Layout.stories.js
@@ -8,15 +8,17 @@ export default {
 
 const sampleText = () => {
   return (
-    <p data-testid="child-element">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </p>
+    <div className="layout-container">
+      <p data-testid="child-element">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </p>
+    </div>
   );
 };
 

--- a/components/text_node_renderer/TextRecur.jsx
+++ b/components/text_node_renderer/TextRecur.jsx
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 
-import Header from "./nodes/Header";
+import HeaderText from "./nodes/HeaderText";
 import LineBreak from "./nodes/LineBreak";
 import ListItem from "./nodes/ListItem";
 import OrderedList from "./nodes/OrderedList";
@@ -12,7 +12,7 @@ import Link from "./nodes/Link";
 
 // todo: more components will like need to be added, but for now, these are the only ones returned in the aem json response
 const NODES = {
-  header: Header,
+  header: HeaderText,
   paragraph: Paragraph,
   link: Link,
   text: Text,

--- a/components/text_node_renderer/nodes/HeaderText.jsx
+++ b/components/text_node_renderer/nodes/HeaderText.jsx
@@ -5,8 +5,9 @@ export default function HeaderText(props) {
     case "h1":
       return (
         <Heading
+          id={"mainHeading"}
           className={props.index === 0 ? "mt-0" : ""}
-          title={props.children}
+          title={props.children[0].props.node.value}
         />
       );
     case "h2":

--- a/components/text_node_renderer/nodes/HeaderText.jsx
+++ b/components/text_node_renderer/nodes/HeaderText.jsx
@@ -1,8 +1,13 @@
-export default function Header(props) {
+import { Heading } from "../../molecules/Heading";
+
+export default function HeaderText(props) {
   switch (props.node.style) {
     case "h1":
       return (
-        <h1 className={props.index === 0 ? "mt-0" : ""}>{props.children}</h1>
+        <Heading
+          className={props.index === 0 ? "mt-0" : ""}
+          title={props.children}
+        />
       );
     case "h2":
       return (

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -14,10 +14,10 @@ describe("Home page", () => {
   })
 
   it("navigates to a project page", () => {
-    cy.get("a[href*=benefits-navigator]").click();
+    cy.get("a[href*=making-easier-get-benefits]").click();
     cy.url().should(
       "equal",
-      Cypress.config().baseUrl + "/en/projects/benefits-navigator"
+      Cypress.config().baseUrl + "/en/projects/making-easier-get-benefits"
     );
   });
 });

--- a/graphql/queries/homePageQuery.graphql
+++ b/graphql/queries/homePageQuery.graphql
@@ -1,6 +1,6 @@
 query getHomePage {
   sclabsPageV1ByPath(
-    _path: "/content/dam/decd-endc/content-fragments/sclabs/pages/home-page"
+    _path: "/content/dam/decd-endc/content-fragments/sclabs/pages/home"
   ) {
     item {
       scId
@@ -121,6 +121,77 @@ query getHomePage {
           scImageCaptionFr {
             json
           }
+        }
+        ... on SclabsCompContentImageV1Model {
+          _model {
+            ... on ModelInfo {
+              title
+            }
+          }
+          scId
+          scLabContent {
+            scId
+            scContentEn {
+              json
+            }
+            scContentFr {
+              json
+            }
+          }
+          scLabImage {
+            ... on SclabsImageV1Model {
+              scId
+              scImageEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileEn {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageMobileFr {
+                ... on ImageRef {
+                  _publishUrl
+                  width
+                  height
+                }
+                ... on DocumentRef {
+                  _publishUrl
+                }
+              }
+              scImageAltTextEn
+              scImageAltTextFr
+              scImageCaptionEn {
+                json
+              }
+              scImageCaptionFr {
+                json
+              }
+            }
+          }
+          scLabLayout
         }
         ... on SclabsButtonV1Model {
           scId

--- a/lib/utils/filterItems.js
+++ b/lib/utils/filterItems.js
@@ -1,7 +1,7 @@
-export const filterProjects = (projects, activeProject) => {
+export const filterItems = (items, activeItem) => {
   //filter out current project from projects array
-  const filteredProjects = projects.filter((currentProject) => {
-    return currentProject.scId !== activeProject;
+  const filteredProjects = items.filter((currentItem) => {
+    return currentItem.scId !== activeItem;
   });
   //slice filtered array to max length of 3 and return new array
   const slicedArray = filteredProjects.slice(0, 3);

--- a/lib/utils/sortUpdatesByDate.js
+++ b/lib/utils/sortUpdatesByDate.js
@@ -1,0 +1,5 @@
+export const sortUpdatesByDate = (array) => {
+  return [...array].sort((a, b) => {
+    return b.scDateModifiedOverwrite.localeCompare(a.scDateModifiedOverwrite);
+  });
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,6 +23,9 @@ const lato = Lato({
 function MyApp({ Component, pageProps }) {
   return (
     <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </Head>
       <main className={`${notoSans.variable} ${lato.variable}`}>
         <Component {...pageProps} />
       </main>

--- a/pages/home.js
+++ b/pages/home.js
@@ -14,6 +14,1749 @@ import FragmentRender from "../components/fragment_renderer/FragmentRender";
 export default function Home(props) {
   const pageData = props.pageData?.item;
   const experimentsData = props.experimentsData;
+  const dictionary = props.dictionary;
+  const updatesData = [
+    {
+      _path:
+        "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/how-feedback-is-shaping-the-estimator",
+      scId: "HOW-FEEDBACK-SHAPING-ESTIMATOR",
+      scPageNameEn: "/en/projects/oas-benefits-estimator/how-feedback-shaping",
+      scPageNameFr:
+        "/fr/projets/estimateur-prestations-sv/faconner-grace-retroaction",
+      scTitleEn: "How feedback is shaping the estimator",
+      scTitleFr: "Façonner l’estimateur grâce à la rétroaction",
+      scShortTitleEn: null,
+      scShortTitleFr: null,
+      scBreadcrumbParentPages: [
+        {
+          scTitleEn: "Service Canada Labs",
+          scTitleFr: "Laboratoires de Service Canada",
+          scPageNameEn: "/en/home",
+          scPageNameFr: "/fr/accueil",
+        },
+        {
+          scTitleEn: "Old Age Security Benefits Estimator",
+          scTitleFr:
+            "Estimateur des prestations de la Sécurité de la vieillesse",
+          scPageNameEn: "/en/projects/oas-benefits-estimator",
+          scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+        },
+      ],
+      scSubject: ["gc:subjects/gv-government-and-politics/government-services"],
+      scKeywordsEn: "feedback, benefits, estimator",
+      scKeywordsFr: "rétroaction, prestations, estimateur",
+      scContentType: [
+        "gc:content-types/promotional-material-featured-articles",
+      ],
+      scOwner: ["gc:institutions/service-canada"],
+      scDateModifiedOverwrite: "2023-12-12",
+      scAudience: null,
+      scRegion: null,
+      scSocialMediaImageEn: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageFr: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageAltTextEn:
+        " Different kinds of feedback being gathered",
+      scSocialMediaImageAltTextFr:
+        " Un rassemblement de différents types de rétroaction",
+      scNoIndex: false,
+      scNoFollow: false,
+      scFragments: [
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-Image-v1",
+          },
+          scId: "ESTIMATOR-REVIEWING-FEEDBACK",
+          scLabContent: [
+            {
+              scId: "ESTIMATOR-REVIEWING-FEEDBACK",
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h1",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "How feedback is shaping the estimator ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "There are many ways to do usability research and use insights to improve client experience. In our beta phase, one of the ways we’re doing this is by collecting feedback from people who try the Old Age Security Benefits Estimator through a survey. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "About 450 visitors have sent responses. This has allowed us to analyze feedback and prioritize changes that are important to our clients. We can see what works and what doesn’t in order to refine the estimator based on their needs. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Reviewing feedback ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Every week, our product team meets for “Feedback Friday” to sort through all the new survey responses. We look at the ratings and comments people shared with us about their experience. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We then organize the survey responses by topic (this is called “affinity mapping”). This gives us a wide view of problem areas and their progression over time. If we see the same comment come up a few times, we know we should take a closer look at what we can do to resolve the issue.",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h1",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Façonner l’estimateur grâce à la rétroaction ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Il y a de nombreuses façons de mener des recherches sur la convivialité et d’utiliser les résultats pour améliorer l’expérience client. Dans notre phase bêta, nous avons notamment recueilli la rétroaction des personnes qui essaient l’Estimateur des prestations de la Sécurité de la vieillesse au moyen d’un sondage. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Environ 450 visiteurs y ont répondu. Cela nous a permis d’analyser la rétroaction et de prioriser les changements qui sont importants pour nos clients. Nous pouvons voir ce qui fonctionne et ce qui ne fonctionne pas afin d’améliorer l’estimateur en fonction de leurs besoins. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Analyse de la rétroaction ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Chaque semaine, notre équipe de produit se réunit pour le ",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "« v",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value: "endredi rétroactio",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "n » ",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value:
+                          "afin de trier toutes les nouvelles réponses au sondage. Nous regardons les évaluations et les commentaires que les gens ont partagés avec nous sur leur expérience. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous organisons ensuite les commentaires par thème (c’est ce qu’on appelle la ",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "« c",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value: "artographie des affinité",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "s »",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value:
+                          "). Cela nous permet d’avoir une vue d’ensemble des problèmes et de leur évolution dans le temps. Si le même commentaire revient plusieurs fois, nous savons que nous devrions examiner de plus près ce que nous pouvons faire pour résoudre le problème. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabImage: {
+            scId: "ESTIMATOR-HOW-FEEDBACK-SHAPING",
+            scImageEn: {
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+              width: 2670,
+              height: 1543,
+            },
+            scImageFr: {
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/feedback.jpg",
+              width: 2670,
+              height: 1543,
+            },
+            scImageMobileEn: null,
+            scImageMobileFr: null,
+            scImageAltTextEn: null,
+            scImageAltTextFr: null,
+            scImageCaptionEn: {
+              json: null,
+            },
+            scImageCaptionFr: {
+              json: null,
+            },
+          },
+          scLabLayout: "default",
+        },
+        {
+          _model: {
+            title: "SCLabs-Content-v1",
+          },
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/using-feedback",
+          scId: "ESTIMATOR-USING-FEEDBACK",
+          scContentEn: {
+            json: [
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "Using feedback",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "The estimator has proven to be user-friendly, but that didn't mean it was serving everyone’s needs. In fact, the initial feedback suggested there were specific things we needed to fix. Below, we show how we’ve used feedback with examples inspired by real survey responses. ",
+                  },
+                ],
+              },
+            ],
+          },
+          scContentFr: {
+            json: [
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "Utilisation de la rétroaction",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "L’estimateur a bien montré être convivial, mais cela ne veut pas dire qu’il répondait aux besoins de tout le monde. En effet, les commentaires initiaux suggéraient qu’il y avait des choses spécifiques que nous devions corriger. Nous montrons ci-dessous comment nous avons utilisé la rétroaction à l’aide d’exemples inspirés de vraies réponses au sondage. ",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-v1",
+          },
+          scId: "ESTIMATOR-FUTURE-ESTIMATE-COMMENT-1",
+          scLabContent: [
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "I didn’t like having to change my birth year to get an estimate",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Je n’aimais pas devoir changer mon année de naissance pour avoir une estimation",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We now generate results that give future estimates to those who aren’t eligible yet. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous générons maintenant des résultats qui donnent des estimations futures aux personnes qui ne sont pas encore admissibles. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabLayout: "quote",
+        },
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-v1",
+          },
+          scId: "ESTIMATOR-DEFERRED-AMOUNT-COMMENT-2",
+          scLabContent: [
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "It should show the benefit to deferral if I start to receive after 65",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "On devrait montrer l’avantage d’un report si je commence à recevoir après 65 ans",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We now automatically show a personalized deferred amount to everyone older than 65. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous affichons maintenant automatiquement un montant reporté personnalisé pour toutes les personnes âgées de plus de 65 ans.",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabLayout: "quote",
+        },
+        {
+          _model: {
+            title: "SCLabs-Content-v1",
+          },
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/using-feedback-2",
+          scId: "ESTIMATOR-USING-FEEDBACK-2",
+          scContentEn: {
+            json: [
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Having access to feedback and being able to make quick updates has allowed us to add features like these and improve where you told us it matters most. We still have a lot of work to do and can’t address every pain point. But by grouping the feedback by topic, we can identify the most common concerns and prioritize solutions. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Here are examples of comments that represent common feedback themes and how we plan to address them: ",
+                  },
+                ],
+              },
+            ],
+          },
+          scContentFr: {
+            json: [
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "En ayant accès aux commentaires et en pouvant faire des mises à jour rapides, nous avons pu ajouter des fonctionnalités comme celles-ci et améliorer ce qui était le plus important pour vous. Nous avons encore beaucoup de travail à faire et nous ne pouvons pas résoudre toutes les difficultés. Mais en regroupant les commentaires par thème, nous pouvons identifier les problèmes les plus courants et prioriser les solutions. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Voici des exemples de commentaires qui illustrent des thèmes communs de la rétroaction et comment nous comptons y répondr",
+                  },
+                  {
+                    nodeType: "span",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "e :",
+                      },
+                    ],
+                    data: {
+                      class: "nowrap",
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-v1",
+          },
+          scId: "ESTIMATOR-INCOME-QUESTION-COMMENT-3",
+          scLabContent: [
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "The income question isn’t clear",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "La question du revenu n’est pas claire",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Our new question will clarify the types of income to include and calculate how much of your work income is exempted. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Notre nouvelle question clarifiera les types de revenus à inclure et calculera la part de votre revenu lié au travail qui est exemptée. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabLayout: "quote",
+        },
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-v1",
+          },
+          scId: "ESTIMATOR-ESTIMATE-COMMENT-4",
+          scLabContent: [
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "I wasn’t given an estimate",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Je n’ai pas reçu d’estimation",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We’ve already added $0 amounts to estimates to remove ambiguity. We’re also going to be changing the look of the results to make information easier to find. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Nous avons déjà ajouté des montants de ",
+                      },
+                      {
+                        nodeType: "span",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "0 $",
+                          },
+                        ],
+                        data: {
+                          class: "nowrap",
+                        },
+                      },
+                      {
+                        nodeType: "text",
+                        value:
+                          " aux estimations afin de résoudre l’ambiguïté. Nous allons également modifier la présentation des résultats pour que les informations soient plus faciles à trouver. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabLayout: "quote",
+        },
+        {
+          _model: {
+            title: "SCLabs-Content-v1",
+          },
+          _path:
+            "/content/dam/decd-endc/content-fragments/sclabs/components/content/projects/oas-benefits-estimator/project-updates/how-feedback-shaping-estimator/measuring-success",
+          scId: "ESTIMATOR-MEASURING-SUCCESS",
+          scContentEn: {
+            json: [
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "Measuring success ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "After we implement solutions, we’re able to tell if an issue has been resolved through comments and ratings. If we’ve made the right improvements, we stop seeing the issue mentioned, and the ratings start showing positive trends. This allows us to measure the success of our new features and make sure that we’ve improved our clients’ experience. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "For example, we can look at our data from before and after the 2 initial fixes mentioned above. If we compare survey ratings from July to those in October, we see that: ",
+                  },
+                ],
+              },
+              {
+                nodeType: "unordered-list",
+                content: [
+                  {
+                    nodeType: "list-item",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "20% more people felt that the tool provided the information they needed ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "list-item",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "15% more people said that the tool made them more aware of the benefits available to them ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "To make sure the estimator stays user-friendly as it evolves, we’re also tracking its ease of use, which has stayed roughly the same at 80%. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "By looking at comments and analytics together, we can see how the changes were received and which pain points are resolved. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "What we’re doing next ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "We’ll keep monitoring our success indicators as we release updated versions of the estimator. In the meantime, keep sending us comments about your experience. We’re listening! ",
+                  },
+                ],
+              },
+            ],
+          },
+          scContentFr: {
+            json: [
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "Mesure du succès ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Après avoir mis en œuvre des solutions, nous pouvons savoir si un problème a été réglé grâce aux commentaires et aux évaluations. Si nous avons apporté les bonnes améliorations, le problème n’est plus mentionné et les évaluations montrent des tendances positives. Cela nous permet de mesurer le succès de nos nouvelles fonctionnalités et de nous assurer que nous avons amélioré l’expérience de nos clients. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Par exemple, nous pouvons regarder nos données avant et après les ",
+                  },
+                  {
+                    nodeType: "span",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "2 premières",
+                      },
+                    ],
+                    data: {
+                      class: "nowrap",
+                    },
+                  },
+                  {
+                    nodeType: "text",
+                    value:
+                      " corrections mentionnées ci-dessus. Si nous comparons les résultats du sondage de juillet à ceux d'octobre, nous constatons que : ",
+                  },
+                ],
+              },
+              {
+                nodeType: "unordered-list",
+                content: [
+                  {
+                    nodeType: "list-item",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "20 % plus de personnes ont trouvé que l’outil leur avait fourni les informations recherchées; ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "list-item",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "15 % plus de personnes ont indiqué que l'outil les avait renseignés sur les prestations qui leur sont offertes. ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Pour nous assurer que l’estimateur reste convivial à mesure qu’il évolue, nous surveillons également sa facilité d'utilisation, qui est restée stable à environ ",
+                  },
+                  {
+                    nodeType: "span",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "80 %",
+                      },
+                    ],
+                    data: {
+                      class: "nowrap",
+                    },
+                  },
+                  {
+                    nodeType: "text",
+                    value: ". ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "En tenant compte à la fois des commentaires et des données analytiques, nous pouvons voir comment les changements ont été reçus et quelles sources de difficultés ont été éliminées. ",
+                  },
+                ],
+              },
+              {
+                nodeType: "header",
+                style: "h2",
+                content: [
+                  {
+                    nodeType: "text",
+                    value: "Ce qui nous attend ",
+                  },
+                ],
+              },
+              {
+                nodeType: "paragraph",
+                content: [
+                  {
+                    nodeType: "text",
+                    value:
+                      "Nous surveillerons nos indicateurs de succès à mesure que nous publierons de nouvelles versions de l'estimateur. Entre-temps, continuez à nous envoyer des commentaires sur votre expérience. Nous sommes à l'écoute! ",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      _path:
+        "/content/dam/decd-endc/content-fragments/sclabs/pages/projects/oas-benefits-estimator/project-updates/what-we-learned",
+      scId: "WHAT-WE-LEARNED",
+      scPageNameEn: "/en/projects/oas-benefits-estimator/what-we-learned",
+      scPageNameFr:
+        "/fr/projets/estimateur-prestations-sv/ce-que-nous-avons-appris",
+      scTitleEn:
+        "What we learned on Service Canada Labs before going live on Canada.ca",
+      scTitleFr:
+        "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca",
+      scShortTitleEn: null,
+      scShortTitleFr: null,
+      scBreadcrumbParentPages: [
+        {
+          scTitleEn: "Service Canada Labs",
+          scTitleFr: "Laboratoires de Service Canada",
+          scPageNameEn: "/en/home",
+          scPageNameFr: "/fr/accueil",
+        },
+        {
+          scTitleEn: "Old Age Security Benefits Estimator",
+          scTitleFr:
+            "Estimateur des prestations de la Sécurité de la vieillesse",
+          scPageNameEn: "/en/projects/oas-benefits-estimator",
+          scPageNameFr: "/fr/projets/estimateur-prestations-sv",
+        },
+      ],
+      scSubject: null,
+      scKeywordsEn: null,
+      scKeywordsFr: null,
+      scContentType: [
+        "gc:content-types/promotional-material-featured-articles",
+      ],
+      scOwner: null,
+      scDateModifiedOverwrite: "2023-07-02",
+      scAudience: null,
+      scRegion: null,
+      scSocialMediaImageEn: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageFr: {
+        _path:
+          "/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        _publishUrl:
+          "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+        width: 2670,
+        height: 1543,
+      },
+      scSocialMediaImageAltTextEn: "People giving feedback",
+      scSocialMediaImageAltTextFr: "Personnes qui donnent de la rétroaction",
+      scNoIndex: false,
+      scNoFollow: false,
+      scFragments: [
+        {
+          _model: {
+            title: "SCLabs-Comp-Content-Image-v1",
+          },
+          scId: "ESTIMATOR-WHAT-WE-LEARNED",
+          scLabContent: [
+            {
+              scId: "OAS-BENEFITS-ESTIMATOR-WHAT-WE-LEARNED",
+              scContentEn: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h1",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "What we learned on Service Canada Labs before going live on Canada.ca",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "On April 12, 2023, we released an alpha version of the Old Age Security Benefits Estimator to the public. The tool was still in an early development phase, but it was working. We knew the earlier we let everyone use it, the earlier we'd get real feedback.",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Since then, over 4,000 people tried it out, and around 200 provided feedback. Here’s what we learned from the feedback collected in our alpha phase, how it’s helping us improve our tool and what’s next for our beta phase.",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Asking experts what they think ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Ideally, the estimator could save someone a trip or a call to Service Canada. That's why we wanted to know if it answered the most common questions about Old Age Security benefits. To find out, we asked Service Canada employees. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "They confirmed that the estimator was able to give answers to common questions about: ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "who these benefits are for ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "how much they can expect to receive ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "when they can expect to receive a letter from Service Canada ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "They told us about other questions they get often, and if they found any missing information. Some even gave us ideas to make this tool even more useful for Canadians. We'll be assessing these during our beta phase and will use this information to continuously improve the estimator. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Using data to improve questions ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We were lucky enough to be able to use data from a similar tool while we were on Service Canada Labs. This helped us gather information about the questions we were asking. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "In alpha, entering an income in the estimator was optional. We wanted to give clients a choice. However, we realized, through our survey, that people were looking for a precise amount in the results. Only providing the maximum income to receive a benefit wasn’t enough. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "The other tool required clients to enter an income. So, we looked at their data. There was nothing to indicate that people didn’t want to do this. The question didn’t stop them from using the tool. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "To give better results, we decided to require income in our beta estimator. This way, we can provide an amount to everyone whose income qualifies, while being confident that the tool is just as easy to use. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Making improvements based on client feedback ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Our main goal for the alpha phase was to get people using the tool and get as much feedback as possible. Anyone who used our tool during our alpha phase could give us their thoughts through an anonymous feedback survey. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We read all the comments and ratings and found it very valuable. Through our survey, we found out that: ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "90% thought the tool was easy to use ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "73% were more aware of the benefits available to them ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Some were satisfied, some had questions, and others wanted to see different features. From the survey responses, we’ve identified the main improvements clients want to see. Many wanted: ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "the ability to get an estimate from a younger age ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "more clarity about which types of income affect benefits ",
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "to have more information about their partner’s results ",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We’ve already started working on these features and other adjustments. For example, in the beta version now on Canada.ca, we’ve added more detailed and visible results for partners. We’re looking forward to having this improvement and other tweaks make the tool better for Canadians. ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Share your feedback ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "We’re still collecting and addressing feedback! The estimator is still in active development and will be evolving to better meet your needs throughout the beta. Expect to see some changes! ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              scContentFr: {
+                json: [
+                  {
+                    nodeType: "header",
+                    style: "h1",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Ce que nous avons appris dans les laboratoires avant notre lancement sur Canada.ca ",
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Le 12 avril 2023, nous avons publié une version alpha de l’Estimateur des prestations de la Sécurité de la vieillesse. L’outil était encore dans une phase de développement préliminaire, mais il fonctionnait. Nous savions que nous pourrions obtenir de la véritable rétroaction plus tôt si nous permettions à tout le monde de l’utiliser. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Depuis, plus de 4 000 personnes l’ont essayé et environ 200 ont donné leur rétroaction. Voici ce que nous avons appris des avis recueillis au cours de notre phase alpha, comment ils nous aident à améliorer notre outil et ce qui nous attend pour notre phase bêta. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Demander aux experts ce qu’ils en pensent ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Idéalement, l’estimateur pourrait épargner à quelqu’un un voyage ou un appel à Service Canada. Voilà pourquoi nous voulions savoir s’il répondait aux questions les plus fréquentes sur les prestations de la Sécurité de la vieillesse. Pour le savoir, nous avons consulté les employés de Service Canada. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Ils ont confirmé que l’estimateur répondait aux questions les plus courantes concernant : ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value: "à qui s’adressent ces prestations; ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "le montant qu’ils peuvent s’attendre à recevoir; ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "quand ils peuvent s’attendre à recevoir une lettre de Service Canada. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Ils nous ont fait part d’autres questions qui leur sont souvent posées et nous ont dit s’ils avaient trouvé des informations manquantes. Certains nous ont même donné des idées pour rendre cet outil encore plus utile pour la population canadienne. Nous évaluerons ces idées au cours de notre phase bêta et nous utiliserons ces informations pour continuer à améliorer l’estimateur. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Utiliser des données pour améliorer les questions ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous avions la chance de pouvoir utiliser les données d’un outil similaire lorsque nous étions sur les laboratoires de Service Canada. Cela nous a permis de recueillir des informations sur nos questions. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Dans la version alpha, il était facultatif de saisir un revenu dans I’estimateur. Nous voulions donner le choix aux clients. Cependant, nous nous sommes rendu compte, grâce à notre sondage, que les gens recherchaient un montant précis dans les résultats. Indiquer le revenu maximum pour recevoir une prestation n’était pas suffisant. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "L’autre outil exigeait que les clients entrent un revenu. Nous avons donc examiné leurs données. Rien n’indiquait que les gens ne voulaient pas remplir ce champ. La question ne les empêchait pas d’utiliser l’outil. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Pour fournir de meilleurs résultats, nous avons décidé d’exiger un revenu dans notre estimateur bêta. De cette manière, nous pouvons fournir un montant à toutes les personnes dont le revenu est admissible, tout en étant assurés que l’outil est tout aussi facile à utiliser. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Apporter des améliorations à partir de la rétroaction des clients ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Notre objectif principal pour la phase alpha était d’amener les gens à utiliser l’outil et de recevoir le plus de rétroaction possible. Toute personne ayant utilisé notre outil pendant la phase alpha pouvait nous faire part de ses impressions en répondant à un sondage anonyme. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous avons lu tous les commentaires et évaluations et les avons trouvés très utiles. Notre sondage nous a permis de constater que : ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "90 % ont trouvé que l’outil était facile à utiliser; ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "73 % étaient plus conscients des prestations qui leur étaient offertes. ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Certains étaient satisfaits, certains avaient des questions et d’autres voulaient voir d’autres fonctionnalités. À partir des réponses au sondage, nous avons identifié les principales améliorations souhaitées par les clients. De nombreuses personnes voulaient : ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "unordered-list",
+                    content: [
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "pouvoir obtenir une estimation d’un plus jeune âge;   ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "plus de clarté sur les types de revenus qui affectent les prestations;  ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                      {
+                        nodeType: "list-item",
+                        content: [
+                          {
+                            nodeType: "text",
+                            value:
+                              "avoir plus d’information sur les résultats de leur partenaire.   ",
+                          },
+                          {
+                            nodeType: "line-break",
+                            content: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous avons déjà commencé à travailler sur ces fonctionnalités et sur d’autres ajustements. Par exemple, dans la version bêta actuellement disponible sur Canada.ca, nous avons ajouté des résultats plus détaillés et plus visibles pour les partenaires. Nous avons hâte de voir cette amélioration et d’autres mises à jour améliorer l’outil pour tous. ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "header",
+                    style: "h2",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value: "Partagez votre avis ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                  {
+                    nodeType: "paragraph",
+                    content: [
+                      {
+                        nodeType: "text",
+                        value:
+                          "Nous continuons à recueillir et à intégrer la rétroaction! L’estimateur est encore en développement actif et évoluera pour mieux répondre à vos besoins tout au long de la version bêta. Attendez-vous à voir des changements! ",
+                      },
+                      {
+                        nodeType: "line-break",
+                        content: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          scLabImage: {
+            scId: "WHAT-WE-LEARNED",
+            scImageEn: {
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+              width: 2670,
+              height: 1543,
+            },
+            scImageFr: {
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/oas-benefits-estimator/what-we-learned.jpg",
+              width: 2670,
+              height: 1543,
+            },
+            scImageMobileEn: null,
+            scImageMobileFr: null,
+            scImageAltTextEn: null,
+            scImageAltTextFr: null,
+            scImageCaptionEn: {
+              json: null,
+            },
+            scImageCaptionFr: {
+              json: null,
+            },
+          },
+          scLabLayout: "default",
+        },
+        {
+          _model: {
+            title: "SCLabs-Button-v1",
+          },
+          scId: "GIVE-FEEDBACK-OAS-ESTIMATOR",
+          scTitleEn: "Give feedback",
+          scTitleFr: "Fournir des commentaires",
+          scDestinationURLEn:
+            "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=eng",
+          scDestinationURLFr:
+            "https://srv217.services.gc.ca/ihst4/Intro.aspx?cid=74938e05-8e91-42a9-8e9d-29daf79f6fe0&lc=fra",
+          scButtonType: ["gc:custom/decd-endc/button-type/secondary"],
+        },
+      ],
+    },
+  ];
 
   const currentProjects = experimentsData.filter((project) => {
     return (
@@ -253,11 +1996,13 @@ export default function Home(props) {
             }
           />
         </Head>
-        <section className="layout-container">
+        <div className="mt-24">
           <FragmentRender
             locale={props.locale}
             fragments={[pageData.scFragments[0]]}
           />
+        </div>
+        <div className="layout-container">
           <h2>
             {props.locale === "en"
               ? pageData.scFragments[1].scContentEn.json[0].content[0].value
@@ -330,17 +2075,52 @@ export default function Home(props) {
             <ul className="grid lg:grid-cols-3 gap-6 list-none ml-0">
               {displayCurrentProjects}
             </ul>
-            <div className="mt-5 flex justify-end">
+            <div className="mt-6 flex justify-end">
               <Link
                 id="projectsLink"
-                href="/projects"
+                href={
+                  props.locale === "en"
+                    ? pageData.scFragments[3].scContentEn.json[0].content[0]
+                        .data.href
+                    : pageData.scFragments[3].scContentFr.json[0].content[0]
+                        .data.href
+                }
                 lang={props.locale}
-                text="See all projects"
+                text={
+                  props.locale === "en"
+                    ? pageData.scFragments[3].scContentEn.json[0].content[0]
+                        .value
+                    : pageData.scFragments[3].scContentFr.json[0].content[0]
+                        .value
+                }
               />
             </div>
           </div>
+        </div>
+        <section>
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={dictionary}
+            heading={
+              props.locale === "en"
+                ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+                : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              props.locale === "en"
+                ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+                : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              props.locale === "en"
+                ? pageData.scFragments[5].scContentEn.json[0].content[0].data
+                    .href
+                : pageData.scFragments[5].scContentFr.json[0].content[0].data
+                    .href
+            }
+          />
         </section>
-        <ExploreUpdates />
       </Layout>
     </>
   );
@@ -356,6 +2136,10 @@ export const getStaticProps = async ({ locale }) => {
   // const { data: updatesData } = await aemServiceInstance.getFragment(
   //   "updatesQuery"
   // )
+  // get dictionary
+  const { data: dictionary } = await aemServiceInstance.getFragment(
+    "dictionaryQuery"
+  );
 
   return {
     props: {
@@ -363,6 +2147,8 @@ export const getStaticProps = async ({ locale }) => {
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
       experimentsData: experimentsData.sclabsPageV1List.items,
+      // updatesData:
+      dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),
     },
     revalidate: process.env.ISR_ENABLED === "true" ? 10 : false,

--- a/pages/home.js
+++ b/pages/home.js
@@ -7,6 +7,8 @@ import aemServiceInstance from "../services/aemServiceInstance";
 import { Heading } from "../components/molecules/Heading";
 import { ContextualAlert } from "../components/molecules/ContextualAlert";
 import Image from "next/image";
+import { Link } from "../components/atoms/Link";
+import { ExploreUpdates } from "../components/organisms/ExploreUpdates";
 
 export default function Home(props) {
   const pageData = props.pageData?.item;
@@ -35,9 +37,11 @@ export default function Home(props) {
     }
 
     // Sort the objects based on the lookup
-    return objects.sort((a, b) => {
+    const sorted = objects.sort((a, b) => {
       return titleOrder[a.scTitleEn] - titleOrder[b.scTitleEn];
     });
+    // Trim to first 3 projects
+    return sorted.slice(0, 3);
   };
 
   const displayCurrentProjects = sortedProjects(currentProjects).map(
@@ -399,10 +403,21 @@ export default function Home(props) {
               }
             />
           </div>
-          <ul className="grid lg:grid-cols-2 gap-4 list-none ml-0">
-            {displayCurrentProjects}
-          </ul>
+          <div className="mb-4">
+            <ul className="grid lg:grid-cols-3 gap-6 list-none ml-0">
+              {displayCurrentProjects}
+            </ul>
+            <div className="mt-5 flex justify-end">
+              <Link
+                id="projectsLink"
+                href="/projects"
+                lang={props.locale}
+                text="See all projects"
+              />
+            </div>
+          </div>
         </section>
+        <ExploreUpdates />
       </Layout>
     </>
   );
@@ -415,6 +430,9 @@ export const getStaticProps = async ({ locale }) => {
   const { data: experimentsData } = await aemServiceInstance.getFragment(
     "projectQuery"
   );
+  // const { data: updatesData } = await aemServiceInstance.getFragment(
+  //   "updatesQuery"
+  // )
 
   return {
     props: {

--- a/pages/home.js
+++ b/pages/home.js
@@ -9,6 +9,7 @@ import { ContextualAlert } from "../components/molecules/ContextualAlert";
 import Image from "next/image";
 import { Link } from "../components/atoms/Link";
 import { ExploreUpdates } from "../components/organisms/ExploreUpdates";
+import FragmentRender from "../components/fragment_renderer/FragmentRender";
 
 export default function Home(props) {
   const pageData = props.pageData?.item;
@@ -253,92 +254,14 @@ export default function Home(props) {
           />
         </Head>
         <section className="layout-container">
-          <div className="grid grid-cols-4">
-            <div className="col-span-4">
-              <Heading
-                tabIndex="-1"
-                id="pageMainTitle"
-                title={
-                  props.locale === "en"
-                    ? pageData.scTitleEn
-                    : pageData.scTitleFr
-                }
-              />
-            </div>
-            <p className="font-body col-span-4 xl:col-span-2 row-start-2">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[1].content[0].value
-                : pageData.scFragments[0].scContentFr.json[1].content[0].value}
-            </p>
-            <p className="font-body col-span-4 xl:col-span-2 row-start-3 pt-4 xxl:pt-0">
-              {props.locale === "en"
-                ? pageData.scFragments[0].scContentEn.json[2].content[0].value
-                : pageData.scFragments[0].scContentFr.json[2].content[0].value}
-            </p>
-            <div className="hidden xl:grid col-span-2 col-start-3 row-start-2 row-span-2">
-              <div className="flex justify-center">
-                <span
-                  className="w-full"
-                  style={{ height: "260px", width: "380px", minWidth: "380px" }}
-                  role="presentation"
-                >
-                  <Image
-                    src={
-                      props.locale === "en"
-                        ? pageData.scFragments[1].scImageEn._publishUrl
-                        : pageData.scFragments[1].scImageFr._publishUrl
-                    }
-                    alt=""
-                    width={pageData.scFragments[1].scImageEn.width}
-                    height={pageData.scFragments[1].scImageEn.height}
-                    sizes="35vw"
-                    priority
-                    quality={100}
-                  />
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="lg:flex">
-            <span className="w-full">
-              <h2>
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[3].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[3].content[0]
-                      .value}{" "}
-              </h2>
-              <p className="font-body">
-                {props.locale === "en"
-                  ? pageData.scFragments[0].scContentEn.json[4].content[0].value
-                  : pageData.scFragments[0].scContentFr.json[4].content[0]
-                      .value}{" "}
-              </p>
-              <ul className="list-disc">
-                <li className="ml-10">
-                  <p className="font-body">
-                    {props.locale === "en"
-                      ? pageData.scFragments[0].scContentEn.json[5].content[0]
-                          .content[0].value
-                      : pageData.scFragments[0].scContentFr.json[5].content[0]
-                          .content[0].value}{" "}
-                  </p>
-                </li>
-                <li className="ml-10">
-                  <p className="font-body">
-                    {props.locale === "en"
-                      ? pageData.scFragments[0].scContentEn.json[5].content[1]
-                          .content[0].value
-                      : pageData.scFragments[0].scContentFr.json[5].content[1]
-                          .content[0].value}{" "}
-                  </p>
-                </li>
-              </ul>
-            </span>
-          </div>
+          <FragmentRender
+            locale={props.locale}
+            fragments={[pageData.scFragments[0]]}
+          />
           <h2>
             {props.locale === "en"
-              ? pageData.scFragments[0].scContentEn.json[6].content[0].value
-              : pageData.scFragments[0].scContentFr.json[6].content[0]
+              ? pageData.scFragments[1].scContentEn.json[0].content[0].value
+              : pageData.scFragments[1].scContentFr.json[0].content[0]
                   .value}{" "}
           </h2>
           <div className="mb-8">

--- a/pages/home.js
+++ b/pages/home.js
@@ -1997,7 +1997,7 @@ export default function Home(props) {
             }
           />
         </Head>
-        <div className="mt-24">
+        <div id="pageMainTitle" className="mt-24">
           <FragmentRender
             locale={props.locale}
             fragments={[pageData.scFragments[0]]}

--- a/pages/home.js
+++ b/pages/home.js
@@ -7,7 +7,8 @@ import aemServiceInstance from "../services/aemServiceInstance";
 import { Heading } from "../components/molecules/Heading";
 import { ContextualAlert } from "../components/molecules/ContextualAlert";
 import Image from "next/image";
-import { Link } from "../components/atoms/Link";
+import { Link as LinkWrapper } from "../components/atoms/Link";
+import Link from "next/link";
 import { ExploreUpdates } from "../components/organisms/ExploreUpdates";
 import FragmentRender from "../components/fragment_renderer/FragmentRender";
 import { sortUpdatesByDate } from "../lib/utils/sortUpdatesByDate";
@@ -2077,7 +2078,8 @@ export default function Home(props) {
               {displayCurrentProjects}
             </ul>
             <div className="mt-6 flex justify-end">
-              <Link
+              <LinkWrapper
+                component={Link}
                 id="projectsLink"
                 href={
                   props.locale === "en"

--- a/pages/home.js
+++ b/pages/home.js
@@ -10,6 +10,7 @@ import Image from "next/image";
 import { Link } from "../components/atoms/Link";
 import { ExploreUpdates } from "../components/organisms/ExploreUpdates";
 import FragmentRender from "../components/fragment_renderer/FragmentRender";
+import { sortUpdatesByDate } from "../lib/utils/sortUpdatesByDate";
 
 export default function Home(props) {
   const pageData = props.pageData?.item;
@@ -2100,7 +2101,7 @@ export default function Home(props) {
         <section>
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={dictionary}
             heading={
               props.locale === "en"

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -11,7 +11,7 @@ import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { filterItems } from "../../../lib/utils/filterItems";
 import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
-export default function BenefitNavigatorArticles(props) {
+export default function BenefitNavigatorArticles({ key, ...props }) {
   const [pageData] = useState(props.pageData);
   const [dictionary] = useState(props.dictionary.items);
 
@@ -156,6 +156,7 @@ export const getStaticProps = async ({ locale, params }) => {
 
   return {
     props: {
+      key: params.id,
       locale: locale,
       pageData: pageData[0],
       updatesData: updatesData.sclabsPageV1List.items,

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -7,6 +7,8 @@ import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
 import { Heading } from "../../../components/molecules/Heading";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function BenefitNavigatorArticles(props) {
   const [pageData] = useState(props.pageData);
@@ -79,6 +81,31 @@ export default function BenefitNavigatorArticles(props) {
             />
           </div>
         </section>
+        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={filterItems(props.updatesData, pageData.scId)}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -100,14 +127,14 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
-  const { data } = await aemServiceInstance.getFragment(
+  const { data: updatesData } = await aemServiceInstance.getFragment(
     "benefitsNavigatorArticlesQuery"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.sclabsPageV1List.items;
+  const pages = updatesData.sclabsPageV1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (
@@ -127,6 +154,7 @@ export const getStaticProps = async ({ locale, params }) => {
     props: {
       locale: locale,
       pageData: pageData[0],
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common", "vc"])),

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -75,6 +75,7 @@ export default function BenefitNavigatorArticles(props) {
             <FragmentRender
               fragments={props.pageData.scFragments}
               locale={props.locale}
+              excludeH1={true}
             />
           </div>
         </section>

--- a/pages/projects/benefits-navigator/[id].js
+++ b/pages/projects/benefits-navigator/[id].js
@@ -9,6 +9,7 @@ import FragmentRender from "../../../components/fragment_renderer/FragmentRender
 import { Heading } from "../../../components/molecules/Heading";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function BenefitNavigatorArticles(props) {
   const [pageData] = useState(props.pageData);
@@ -84,7 +85,10 @@ export default function BenefitNavigatorArticles(props) {
         {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(props.updatesData, pageData.scId)}
+            updatesData={filterItems(
+              sortUpdatesByDate(props.updatesData),
+              pageData.scId
+            )}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -213,7 +213,7 @@ export default function BenefitsNavigatorOverview(props) {
           />
         </Head>
 
-        <div className="layout-container">
+        <div className="layout-container mb-24">
           <section aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
               <div className="col-span-2">

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -13,7 +13,7 @@ import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import TextRender from "../../../components/text_node_renderer/TextRender";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { shuffle } from "../../../lib/utils/shuffle";
-import { filterProjects } from "../../../lib/utils/filterProjects";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function BenefitsNavigatorOverview(props) {
   const [allProjects] = useState(props.allProjects);
@@ -626,7 +626,7 @@ export default function BenefitsNavigatorOverview(props) {
         ) : null}
         <ExploreProjects
           locale={props.locale}
-          projects={filterProjects(allProjects, pageData.scId)}
+          projects={filterItems(allProjects, pageData.scId)}
         />
       </Layout>
     </>

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -14,6 +14,7 @@ import TextRender from "../../../components/text_node_renderer/TextRender";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { shuffle } from "../../../lib/utils/shuffle";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function BenefitsNavigatorOverview(props) {
   const [allProjects] = useState(props.allProjects);
@@ -602,7 +603,7 @@ export default function BenefitsNavigatorOverview(props) {
         {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -12,6 +12,7 @@ import { generateCollapseElements } from "../../../lib/utils/generateCollapseEle
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
 import TextRender from "../../../components/text_node_renderer/TextRender";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function BenefitsNavigatorOverview(props) {
   const [pageData] = useState(props.pageData.item);
@@ -25,33 +26,6 @@ export default function BenefitsNavigatorOverview(props) {
         item.scId === "SUMMARY"
     )
   );
-
-  const displayProjectUpdates = updatesData.map((update) => (
-    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
-      <Card
-        showImage
-        imgSrc={
-          props.locale === "en"
-            ? `https://www.canada.ca${update.scSocialMediaImageEn?._path}`
-            : `https://www.canada.ca${update.scSocialMediaImageFr?._path}`
-        }
-        imgAlt={
-          props.locale === "en"
-            ? update.scSocialMediaImageAltTextEn
-            : update.scSocialMediaImageAltTextFr
-        }
-        imgHeight={update.scSocialMediaImageEn.height}
-        imgWidth={update.scSocialMediaImageEn.width}
-        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
-        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-        description={`${
-          props.locale === "en"
-            ? props.dictionary.items[11].scTermEn
-            : props.dictionary.items[11].scTermFr
-        } ${update.scDateModifiedOverwrite}`}
-      />
-    </li>
-  ));
 
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
@@ -622,17 +596,32 @@ export default function BenefitsNavigatorOverview(props) {
               </p>
             </section>
           </div>
-
-          {/* Todo: add locale files and use i18next for translations */}
-          <h2>
-            {props.locale === "en"
-              ? "Project updates"
-              : "Mises à jour du projet"}
-          </h2>
-          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0">
-            {displayProjectUpdates}
-          </ul>
         </div>
+        {props.updatesData.length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -326,22 +326,22 @@ export default function BenefitsNavigatorOverview(props) {
                 ? pageData.scFragments[3].scContentEn.json[2].content[0].value
                 : pageData.scFragments[3].scContentFr.json[2].content[0].value}
             </p>
-            <ul className="col-span-12 xl:col-span-8">
-              <li>
+            <ul className="list-disc col-span-12 xl:col-span-8">
+              <li className="ml-10 text-[20px]">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[3].content[0]
                       .content[0].value
                   : pageData.scFragments[3].scContentFr.json[3].content[0]
                       .content[0].value}
               </li>
-              <li>
+              <li className="ml-10 text-[20px]">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[3].content[1]
                       .content[0].value
                   : pageData.scFragments[3].scContentFr.json[3].content[1]
                       .content[0].value}
               </li>
-              <li>
+              <li className="ml-10 text-[20px]">
                 {props.locale === "en"
                   ? pageData.scFragments[3].scContentEn.json[3].content[2]
                       .content[0].value

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -46,8 +46,8 @@ export default function BenefitsNavigatorOverview(props) {
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
         description={`${
           props.locale === "en"
-            ? props.dictionary.items[9].scTermEn
-            : props.dictionary.items[9].scTermFr
+            ? props.dictionary.items[11].scTermEn
+            : props.dictionary.items[11].scTermFr
         } ${update.scDateModifiedOverwrite}`}
       />
     </li>

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -11,7 +11,7 @@ import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
-export default function MscaDashboardArticles(props) {
+export default function MscaDashboardArticles({ key, ...props }) {
   const [pageData] = useState(props.pageData);
   const [dictionary] = useState(props.dictionary.items);
 
@@ -155,6 +155,7 @@ export const getStaticProps = async ({ locale, params }) => {
 
   return {
     props: {
+      key: params.id,
       locale: locale,
       pageData: pageData[0],
       updatesData: updatesData.sclabsPageV1List.items,

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -9,6 +9,7 @@ import FragmentRender from "../../../components/fragment_renderer/FragmentRender
 import { Heading } from "../../../components/molecules/Heading";
 import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function MscaDashboardArticles(props) {
   const [pageData] = useState(props.pageData);
@@ -84,7 +85,9 @@ export default function MscaDashboardArticles(props) {
         {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(props.updatesData, pageData.scId)}
+            updatesData={filterItems(
+              sortUpdatesByDate(props.updatesData, pageData.scId)
+            )}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -7,6 +7,8 @@ import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
 import { Heading } from "../../../components/molecules/Heading";
+import { filterItems } from "../../../lib/utils/filterItems";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function MscaDashboardArticles(props) {
   const [pageData] = useState(props.pageData);
@@ -79,6 +81,31 @@ export default function MscaDashboardArticles(props) {
             />
           </div>
         </section>
+        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={filterItems(props.updatesData, pageData.scId)}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -100,14 +127,14 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
-  const { data } = await aemServiceInstance.getFragment(
+  const { data: updatesData } = await aemServiceInstance.getFragment(
     "getMSCADashboardArticles"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.sclabsPageV1List.items;
+  const pages = updatesData.sclabsPageV1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (
@@ -127,6 +154,7 @@ export const getStaticProps = async ({ locale, params }) => {
     props: {
       locale: locale,
       pageData: pageData[0],
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common", "vc"])),

--- a/pages/projects/dashboard/[id].js
+++ b/pages/projects/dashboard/[id].js
@@ -75,6 +75,7 @@ export default function MscaDashboardArticles(props) {
             <FragmentRender
               fragments={props.pageData.scFragments}
               locale={props.locale}
+              excludeH1={true}
             />
           </div>
         </section>

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -15,7 +15,7 @@ import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { useState } from "react";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
-import { filterProjects } from "../../../lib/utils/filterProjects";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function MscaDashboard(props) {
   const pageData = props.pageData?.item;
@@ -720,7 +720,7 @@ export default function MscaDashboard(props) {
         ) : null}
         <ExploreProjects
           locale={props.locale}
-          projects={filterProjects(allProjects, pageData.scId)}
+          projects={filterItems(allProjects, pageData.scId)}
         />
       </Layout>
     </>

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -16,6 +16,7 @@ import { useState } from "react";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function MscaDashboard(props) {
   const pageData = props.pageData?.item;
@@ -696,7 +697,7 @@ export default function MscaDashboard(props) {
         {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={props.dictionary}
             heading={
               "Dashboard project updates"

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -324,29 +324,29 @@ export default function MscaDashboard(props) {
                   : pageData.scFragments[3].scContentFr.json[2].content[0]
                       .value}
               </p>
-              <ul className="col-span-12 xl:col-span-8">
-                <li>
+              <ul className="list-disc col-span-12 xl:col-span-8">
+                <li className="ml-10 text-[20px]">
                   {props.locale === "en"
                     ? pageData.scFragments[3].scContentEn.json[3].content[0]
                         .content[0].value
                     : pageData.scFragments[3].scContentFr.json[3].content[0]
                         .content[0].value}
                 </li>
-                <li>
+                <li className="ml-10 text-[20px]">
                   {props.locale === "en"
                     ? pageData.scFragments[3].scContentEn.json[3].content[1]
                         .content[0].value
                     : pageData.scFragments[3].scContentFr.json[3].content[1]
                         .content[0].value}
                 </li>
-                <li>
+                <li className="ml-10 text-[20px]">
                   {props.locale === "en"
                     ? pageData.scFragments[3].scContentEn.json[3].content[2]
                         .content[0].value
                     : pageData.scFragments[3].scContentFr.json[3].content[2]
                         .content[0].value}
                 </li>
-                <li>
+                <li className="ml-10 text-[20px]">
                   {props.locale === "en"
                     ? pageData.scFragments[3].scContentEn.json[3].content[3]
                         .content[0].value
@@ -726,7 +726,7 @@ export const getStaticProps = async ({ locale }) => {
   );
   // get page data from AEM
   const { data: updatesData } = await aemServiceInstance.getFragment(
-    "getMSCADashBoardArticles"
+    "getMSCADashboardArticles"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -209,7 +209,7 @@ export default function MscaDashboard(props) {
           />
         </Head>
 
-        <div className="layout-container">
+        <div className="layout-container mb-24">
           <section aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
               <div className="col-span-2">

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -12,6 +12,7 @@ import { ActionButton } from "../../../components/atoms/ActionButton";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
 import TextRender from "../../../components/text_node_renderer/TextRender";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function MscaDashboard(props) {
   const pageData = props.pageData?.item;
@@ -688,6 +689,31 @@ export default function MscaDashboard(props) {
             </p>
           </section>
         </div>
+        {props.updatesData.length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={props.dictionary}
+            heading={
+              "Dashboard project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -697,6 +723,10 @@ export const getStaticProps = async ({ locale }) => {
   // get page data from AEM
   const { data: pageData } = await aemServiceInstance.getFragment(
     "getMSCADashBoardPage"
+  );
+  // get page data from AEM
+  const { data: updatesData } = await aemServiceInstance.getFragment(
+    "getMSCADashBoardArticles"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
@@ -708,6 +738,7 @@ export const getStaticProps = async ({ locale }) => {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       pageData: pageData.sclabsPageV1ByPath,
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       ...(await serverSideTranslations(locale, ["common"])),
     },

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -8,6 +8,8 @@ import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
 import { Heading } from "../../../components/molecules/Heading";
+import { filterItems } from "../../../lib/utils/filterItems";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function DigitalStandardsArticles(props) {
   const { t } = useTranslation("common");
@@ -81,6 +83,31 @@ export default function DigitalStandardsArticles(props) {
             />
           </div>
         </section>
+        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={filterItems(props.updatesData, pageData.scId)}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -103,14 +130,14 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
-  const { data } = await aemServiceInstance.getFragment(
+  const { data: updatesData } = await aemServiceInstance.getFragment(
     "getDigitalStandardsPlaybookArticles"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.sclabsPageV1List.items;
+  const pages = updatesData.sclabsPageV1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (
@@ -130,6 +157,7 @@ export const getStaticProps = async ({ locale, params }) => {
     props: {
       locale: locale,
       pageData: pageData[0],
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -12,7 +12,7 @@ import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
-export default function DigitalStandardsArticles(props) {
+export default function DigitalStandardsArticles({ key, ...props }) {
   const { t } = useTranslation("common");
   const [pageData] = useState(props.pageData);
   const [dictionary] = useState(props.dictionary.items);
@@ -159,6 +159,7 @@ export const getStaticProps = async ({ locale, params }) => {
 
   return {
     props: {
+      key: params.id,
       locale: locale,
       pageData: pageData[0],
       updatesData: updatesData.sclabsPageV1List.items,

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -10,6 +10,7 @@ import FragmentRender from "../../../components/fragment_renderer/FragmentRender
 import { Heading } from "../../../components/molecules/Heading";
 import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function DigitalStandardsArticles(props) {
   const { t } = useTranslation("common");
@@ -86,7 +87,10 @@ export default function DigitalStandardsArticles(props) {
         {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(props.updatesData, pageData.scId)}
+            updatesData={filterItems(
+              sortUpdatesByDate(props.updatesData),
+              pageData.scId
+            )}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/digital-standards-playbook/[id].js
+++ b/pages/projects/digital-standards-playbook/[id].js
@@ -77,6 +77,7 @@ export default function DigitalStandardsArticles(props) {
             <FragmentRender
               fragments={props.pageData.scFragments}
               locale={props.locale}
+              excludeH1={true}
             />
           </div>
         </section>

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -10,6 +10,7 @@ import { Heading } from "../../../components/molecules/Heading";
 import { ActionButton } from "../../../components/atoms/ActionButton";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function DigitalStandardsPlaybookPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -441,17 +442,32 @@ export default function DigitalStandardsPlaybookPage(props) {
               </p>
             </div>
           </section>
-          <section id="project-updates">
-            <h2>
-              {props.locale === "en"
-                ? props.dictionary.items[11].scTermEn
-                : props.dictionary.items[11].scTermFr}
-            </h2>
-            <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0 mb-12">
-              {displayProjectUpdates}
-            </ul>
-          </section>
         </div>
+        {props.updatesData.length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={props.dictionary}
+            heading={
+              "Digital standards playbook project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -14,6 +14,7 @@ import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function DigitalStandardsPlaybookPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -423,7 +424,7 @@ export default function DigitalStandardsPlaybookPage(props) {
         {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={props.dictionary}
             heading={
               "Digital standards playbook project updates"

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -28,33 +28,6 @@ export default function DigitalStandardsPlaybookPage(props) {
       item.scId === "SUMMARY"
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
-    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
-      <Card
-        showImage
-        imgSrc={
-          props.locale === "en"
-            ? `https://www.canada.ca${update.scSocialMediaImageEn?._path}`
-            : `https://www.canada.ca${update.scSocialMediaImageFr?._path}`
-        }
-        imgAlt={
-          props.locale === "en"
-            ? update.scSocialMediaImageAltTextEn
-            : update.scSocialMediaImageAltTextFr
-        }
-        imgHeight={update.scSocialMediaImageEn.height}
-        imgWidth={update.scSocialMediaImageEn.width}
-        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
-        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-        description={`${
-          props.locale === "en"
-            ? props.dictionary.items[11].scTermEn
-            : props.dictionary.items[11].scTermFr
-        } ${update.scDateModifiedOverwrite}`}
-      />
-    </li>
-  ));
-
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
@@ -235,7 +208,7 @@ export default function DigitalStandardsPlaybookPage(props) {
           />
         </Head>
 
-        <div className="layout-container">
+        <div className="layout-container mb-24">
           <section aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
               <div className="col-span-2">

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -43,8 +43,8 @@ export default function DigitalStandardsPlaybookPage(props) {
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
         description={`${
           props.locale === "en"
-            ? props.dictionary.items[9].scTermEn
-            : props.dictionary.items[9].scTermFr
+            ? props.dictionary.items[11].scTermEn
+            : props.dictionary.items[11].scTermFr
         } ${update.scDateModifiedOverwrite}`}
       />
     </li>

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -13,7 +13,7 @@ import stageDictionary from "../../../lib/utils/stageDictionary";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
-import { filterProjects } from "../../../lib/utils/filterProjects";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function DigitalStandardsPlaybookPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -447,7 +447,7 @@ export default function DigitalStandardsPlaybookPage(props) {
         ) : null}
         <ExploreProjects
           locale={props.locale}
-          projects={filterProjects(allProjects, pageData.scId)}
+          projects={filterItems(allProjects, pageData.scId)}
         />
       </Layout>
     </>

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -10,6 +10,7 @@ import FragmentRender from "../../../components/fragment_renderer/FragmentRender
 import { Heading } from "../../../components/molecules/Heading";
 import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function IntegratedChannelStrategyArticles(props) {
   const { t } = useTranslation("common");
@@ -86,7 +87,10 @@ export default function IntegratedChannelStrategyArticles(props) {
         {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(props.updatesData, pageData.scId)}
+            updatesData={filterItems(
+              sortUpdatesByDate(props.updatesData),
+              pageData.scId
+            )}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -8,6 +8,8 @@ import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
 import { Heading } from "../../../components/molecules/Heading";
+import { filterItems } from "../../../lib/utils/filterItems";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function IntegratedChannelStrategyArticles(props) {
   const { t } = useTranslation("common");
@@ -81,6 +83,31 @@ export default function IntegratedChannelStrategyArticles(props) {
             />
           </div>
         </section>
+        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={filterItems(props.updatesData, pageData.scId)}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -103,14 +130,14 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
-  const { data } = await aemServiceInstance.getFragment(
+  const { data: updatesData } = await aemServiceInstance.getFragment(
     "integratedChannelStrategyArticlesQuery"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.sclabsPageV1List.items;
+  const pages = updatesData.sclabsPageV1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (
@@ -130,6 +157,7 @@ export const getStaticProps = async ({ locale, params }) => {
     props: {
       locale: locale,
       pageData: pageData[0],
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -12,7 +12,7 @@ import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
-export default function IntegratedChannelStrategyArticles(props) {
+export default function IntegratedChannelStrategyArticles({ key, ...props }) {
   const { t } = useTranslation("common");
   const [pageData] = useState(props.pageData);
   const [dictionary] = useState(props.dictionary.items);
@@ -159,6 +159,7 @@ export const getStaticProps = async ({ locale, params }) => {
 
   return {
     props: {
+      key: params.id,
       locale: locale,
       pageData: pageData[0],
       updatesData: updatesData.sclabsPageV1List.items,

--- a/pages/projects/making-easier-get-benefits/[id].js
+++ b/pages/projects/making-easier-get-benefits/[id].js
@@ -77,6 +77,7 @@ export default function IntegratedChannelStrategyArticles(props) {
             <FragmentRender
               fragments={props.pageData.scFragments}
               locale={props.locale}
+              excludeH1={true}
             />
           </div>
         </section>

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -29,33 +29,6 @@ export default function IntegratedChannelStrategyPage(props) {
     )
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
-    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
-      <Card
-        showImage
-        imgSrc={
-          props.locale === "en"
-            ? `https://www.canada.ca${update.scSocialMediaImageEn._path}`
-            : `https://www.canada.ca${update.scSocialMediaImageFr._path}`
-        }
-        imgAlt={
-          (props.locale === "en"
-            ? update.scSocialMediaImageAltTextEn
-            : update.scSocialMediaImageAltTextFr) ?? ""
-        }
-        imgHeight={update.scSocialMediaImageEn.height}
-        imgWidth={update.scSocialMediaImageEn.width}
-        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
-        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-        description={`${
-          props.locale === "en"
-            ? props.dictionary.items[11].scTermEn
-            : props.dictionary.items[11].scTermFr
-        } ${update.scDateModifiedOverwrite}`}
-      />
-    </li>
-  ));
-
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
@@ -236,7 +209,7 @@ export default function IntegratedChannelStrategyPage(props) {
           />
         </Head>
 
-        <div className="layout-container">
+        <div className="layout-container mb-24">
           <section aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
               <div className="col-span-2">

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -13,7 +13,7 @@ import stageDictionary from "../../../lib/utils/stageDictionary";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
-import { filterProjects } from "../../../lib/utils/filterProjects";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function IntegratedChannelStrategyPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -348,7 +348,7 @@ export default function IntegratedChannelStrategyPage(props) {
         ) : null}
         <ExploreProjects
           locale={props.locale}
-          projects={filterProjects(allProjects, pageData.scId)}
+          projects={filterItems(allProjects, pageData.scId)}
         />
       </Layout>
     </>

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -11,6 +11,7 @@ import { Heading } from "../../../components/molecules/Heading";
 import TextRender from "../../../components/text_node_renderer/TextRender";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function IntegratedChannelStrategyPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -343,10 +344,32 @@ export default function IntegratedChannelStrategyPage(props) {
               />
             </div>
           </div>
-          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0 mb-12">
-            {displayProjectUpdates}
-          </ul>
         </div>
+        {props.updatesData.length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={props.dictionary}
+            heading={
+              "Digital standards playbook project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -45,8 +45,8 @@ export default function IntegratedChannelStrategyPage(props) {
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
         description={`${
           props.locale === "en"
-            ? props.dictionary.items[9].scTermEn
-            : props.dictionary.items[9].scTermFr
+            ? props.dictionary.items[11].scTermEn
+            : props.dictionary.items[11].scTermFr
         } ${update.scDateModifiedOverwrite}`}
       />
     </li>

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -14,6 +14,7 @@ import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function IntegratedChannelStrategyPage(props) {
   const [pageData] = useState(props.pageData.item);
@@ -324,7 +325,7 @@ export default function IntegratedChannelStrategyPage(props) {
         {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={props.dictionary}
             heading={
               "Digital standards playbook project updates"

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -12,7 +12,7 @@ import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
-export default function OASBenefitsEstimatorArticles(props) {
+export default function OASBenefitsEstimatorArticles({ key, ...props }) {
   const { t } = useTranslation("common");
   const [pageData] = useState(props.pageData);
   const [dictionary] = useState(props.dictionary.items);
@@ -84,13 +84,10 @@ export default function OASBenefitsEstimatorArticles(props) {
             />
           </div>
         </section>
-        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+        {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(
-              sortUpdatesByDate(props.updatesData),
-              pageData.scId
-            )}
+            updatesData={props.updatesData}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"
@@ -159,9 +156,12 @@ export const getStaticProps = async ({ locale, params }) => {
 
   return {
     props: {
+      key: params.id,
       locale: locale,
       pageData: pageData[0],
-      updatesData: updatesData.sclabsPageV1List.items,
+      updatesData: sortUpdatesByDate(
+        filterItems(updatesData.sclabsPageV1List.items, pageData[0].scId)
+      ),
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -8,6 +8,8 @@ import { getAllUpdateIds } from "../../../lib/utils/getAllUpdateIds";
 import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
 import { Heading } from "../../../components/molecules/Heading";
+import { filterItems } from "../../../lib/utils/filterItems";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function OASBenefitsEstimatorArticles(props) {
   const { t } = useTranslation("common");
@@ -81,6 +83,31 @@ export default function OASBenefitsEstimatorArticles(props) {
             />
           </div>
         </section>
+        {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={filterItems(props.updatesData, pageData.scId)}
+            dictionary={props.dictionary}
+            heading={
+              "Benefits navigator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );
@@ -103,14 +130,14 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ locale, params }) => {
   // Get pages data
-  const { data } = await aemServiceInstance.getFragment(
+  const { data: updatesData } = await aemServiceInstance.getFragment(
     "oasBenefitsEstimatorArticlesQuery"
   );
   // get dictionary
   const { data: dictionary } = await aemServiceInstance.getFragment(
     "dictionaryQuery"
   );
-  const pages = data.sclabsPageV1List.items;
+  const pages = updatesData.sclabsPageV1List.items;
   // Return page data that matches the current page being built
   const pageData = pages.filter((page) => {
     return (
@@ -130,6 +157,7 @@ export const getStaticProps = async ({ locale, params }) => {
     props: {
       locale: locale,
       pageData: pageData[0],
+      updatesData: updatesData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
       ...(await serverSideTranslations(locale, ["common"])),

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -10,6 +10,7 @@ import FragmentRender from "../../../components/fragment_renderer/FragmentRender
 import { Heading } from "../../../components/molecules/Heading";
 import { filterItems } from "../../../lib/utils/filterItems";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function OASBenefitsEstimatorArticles(props) {
   const { t } = useTranslation("common");
@@ -86,7 +87,10 @@ export default function OASBenefitsEstimatorArticles(props) {
         {filterItems(props.updatesData, pageData.scId).length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={filterItems(props.updatesData, pageData.scId)}
+            updatesData={filterItems(
+              sortUpdatesByDate(props.updatesData),
+              pageData.scId
+            )}
             dictionary={props.dictionary}
             heading={
               "Benefits navigator project updates"

--- a/pages/projects/oas-benefits-estimator/[id].js
+++ b/pages/projects/oas-benefits-estimator/[id].js
@@ -77,6 +77,7 @@ export default function OASBenefitsEstimatorArticles(props) {
             <FragmentRender
               fragments={props.pageData.scFragments}
               locale={props.locale}
+              excludeH1={true}
             />
           </div>
         </section>

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -13,7 +13,7 @@ import stageDictionary from "../../../lib/utils/stageDictionary";
 import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
-import { filterProjects } from "../../../lib/utils/filterProjects";
+import { filterItems } from "../../../lib/utils/filterItems";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -401,7 +401,7 @@ export default function OasBenefitsEstimator(props) {
         ) : null}
         <ExploreProjects
           locale={props.locale}
-          projects={filterProjects(allProjects, pageData.scId)}
+          projects={filterItems(allProjects, pageData.scId)}
         />
       </Layout>
     </>

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -29,33 +29,6 @@ export default function OasBenefitsEstimator(props) {
     )
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
-    <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
-      <Card
-        showImage
-        imgSrc={
-          props.locale === "en"
-            ? `https://www.canada.ca${update.scSocialMediaImageEn._path}`
-            : `https://www.canada.ca${update.scSocialMediaImageFr._path}`
-        }
-        imgAlt={
-          (props.locale === "en"
-            ? update.scSocialMediaImageAltTextEn
-            : update.scSocialMediaImageAltTextFr) ?? ""
-        }
-        imgHeight={update.scSocialMediaImageEn.height}
-        imgWidth={update.scSocialMediaImageEn.width}
-        title={props.locale === "en" ? update.scTitleEn : update.scTitleFr}
-        href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
-        description={`${
-          props.locale === "en"
-            ? props.dictionary.items[11].scTermEn
-            : props.dictionary.items[11].scTermFr
-        } ${update.scDateModifiedOverwrite}`}
-      />
-    </li>
-  ));
-
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
@@ -236,7 +209,7 @@ export default function OasBenefitsEstimator(props) {
           />
         </Head>
 
-        <div className="layout-container">
+        <div className="layout-container mb-24">
           <section aria-labelledby="pageMainTitle">
             <div className="flex flex-col break-words lg:grid lg:grid-cols-2">
               <div className="col-span-2">

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -44,8 +44,8 @@ export default function OasBenefitsEstimator(props) {
         href={props.locale === "en" ? update.scPageNameEn : update.scPageNameFr}
         description={`${
           props.locale === "en"
-            ? props.dictionary.items[9].scTermEn
-            : props.dictionary.items[9].scTermFr
+            ? props.dictionary.items[11].scTermEn
+            : props.dictionary.items[11].scTermFr
         } ${update.scDateModifiedOverwrite}`}
       />
     </li>

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -10,6 +10,7 @@ import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import { Heading } from "../../../components/molecules/Heading";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -395,15 +396,32 @@ export default function OasBenefitsEstimator(props) {
               ariaExpanded={props.ariaExpanded}
             />
           </div>
-          <h2>
-            {props.locale === "en"
-              ? props.dictionary.items[11].scTermEn
-              : props.dictionary.items[11].scTermFr}
-          </h2>
-          <ul className="grid lg:grid-cols-12 gap-x-4 lg:gap-y-12 list-none ml-0 mb-12">
-            {displayProjectUpdates}
-          </ul>
         </div>
+        {props.updatesData.length !== 0 ? (
+          <ExploreUpdates
+            locale={props.locale}
+            updatesData={updatesData}
+            dictionary={props.dictionary}
+            heading={
+              "OAS Benefits Estimator project updates"
+              // props.locale === "en"
+              //   ? pageData.scFragments[4].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[4].scContentFr.json[0].content[0].value
+            }
+            linkLabel={
+              "See all updates about this project"
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].value
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].value
+            }
+            href={
+              ""
+              // props.locale === "en"
+              //   ? pageData.scFragments[5].scContentEn.json[0].content[0].data.href
+              //   : pageData.scFragments[5].scContentFr.json[0].content[0].data.href
+            }
+          />
+        ) : null}
       </Layout>
     </>
   );

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -14,6 +14,7 @@ import { ExploreUpdates } from "../../../components/organisms/ExploreUpdates";
 import { ExploreProjects } from "../../../components/organisms/ExploreProjects";
 import { shuffle } from "../../../lib/utils/shuffle";
 import { filterItems } from "../../../lib/utils/filterItems";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
@@ -377,7 +378,7 @@ export default function OasBenefitsEstimator(props) {
         {props.updatesData.length !== 0 ? (
           <ExploreUpdates
             locale={props.locale}
-            updatesData={updatesData}
+            updatesData={sortUpdatesByDate(updatesData)}
             dictionary={props.dictionary}
             heading={
               "OAS Benefits Estimator project updates"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -211,6 +211,7 @@ module.exports = {
           link: "#0535d2",
           text: "#335075",
           hover: "#083DCA",
+          "updates-blue": "#F0F7FF",
           "experiment-blue": "#004986",
           "projects-link": "#2B4380",
           "projects-link-hover": "#0535d2",


### PR DESCRIPTION
This PR covers two tasks

### [Create "Read our latest project updates" section](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=215234)
### [Create new "Project updates" section](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=215243)

![Screenshot 2024-06-07 at 3 36 11 PM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/a18b9b29-c65d-4323-a85c-b2885aa17332)

The new "Explore our updates" section has been implemented on the homepage, all project pages, and all article pages.
Updates are always sorted with most recent first.

Created a unit test and story for the new ExploreUpdates.js component.

When the content for the ExploreUpdates and ExploreProjects sections is ready in AEM, we will revisit to remove the hardcoded values for the header on ExploreUpdates on some pages etc.

## Test Instructions

1. `yarn dev` (also do this with `yarn build` + `yarn start`)
2. Navigate to home page, project pages and article pages
3. See that updates section is rendering properly, is sorted by most recent, is mobile responsive, has proper styling, and does not include the current page
