### PR TITLE
sorted project updates by date on old design

### DIFF
--- a/lib/utils/sortUpdatesByDate.js
+++ b/lib/utils/sortUpdatesByDate.js
@@ -1,0 +1,5 @@
+export const sortUpdatesByDate = (array) => {
+  return [...array].sort((a, b) => {
+    return b.scDateModifiedOverwrite.localeCompare(a.scDateModifiedOverwrite);
+  });
+};

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -15,8 +15,7 @@ import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function BenefitsNavigatorOverview(props) {
   const [pageData] = useState(props.pageData.item);
-  const [updatesData] = useState(props.updatesData);
-  const sortedUpdates = sortUpdatesByDate(updatesData);
+  const updatesData = sortUpdatesByDate(props.updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -27,7 +26,7 @@ export default function BenefitsNavigatorOverview(props) {
     )
   );
 
-  const displayProjectUpdates = sortedUpdates.map((update) => (
+  const displayProjectUpdates = updatesData.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/benefits-navigator/index.js
+++ b/pages/projects/benefits-navigator/index.js
@@ -11,10 +11,12 @@ import { Collapse } from "../../../components/molecules/Collapse";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
 import TextRender from "../../../components/text_node_renderer/TextRender";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function BenefitsNavigatorOverview(props) {
   const [pageData] = useState(props.pageData.item);
   const [updatesData] = useState(props.updatesData);
+  const sortedUpdates = sortUpdatesByDate(updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -25,7 +27,7 @@ export default function BenefitsNavigatorOverview(props) {
     )
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
+  const displayProjectUpdates = sortedUpdates.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/dashboard/index.js
+++ b/pages/projects/dashboard/index.js
@@ -13,10 +13,11 @@ import stageDictionary from "../../../lib/utils/stageDictionary";
 import TextRender from "../../../components/text_node_renderer/TextRender";
 import Card from "../../../components/molecules/Card";
 import FragmentRender from "../../../components/fragment_renderer/FragmentRender";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function MscaDashboard(props) {
   const pageData = props.pageData?.item;
-  const updatesData = props.updatesData;
+  const updatesData = sortUpdatesByDate(props.updatesData);
 
   const filteredDictionary = props.dictionary?.items?.filter(
     (item) =>

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -10,10 +10,12 @@ import { Heading } from "../../../components/molecules/Heading";
 import { ActionButton } from "../../../components/atoms/ActionButton";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function DigitalStandardsPlaybookPage(props) {
   const [pageData] = useState(props.pageData.item);
   const [updatesData] = useState(props.updatesData);
+  const sortedUpdates = sortUpdatesByDate(updatesData);
 
   const filteredDictionary = props.dictionary?.items?.filter(
     (item) =>
@@ -23,7 +25,7 @@ export default function DigitalStandardsPlaybookPage(props) {
       item.scId === "SUMMARY"
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
+  const displayProjectUpdates = sortedUpdates.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/digital-standards-playbook/index.js
+++ b/pages/projects/digital-standards-playbook/index.js
@@ -14,8 +14,7 @@ import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function DigitalStandardsPlaybookPage(props) {
   const [pageData] = useState(props.pageData.item);
-  const [updatesData] = useState(props.updatesData);
-  const sortedUpdates = sortUpdatesByDate(updatesData);
+  const updatesData = sortUpdatesByDate(props.updatesData);
 
   const filteredDictionary = props.dictionary?.items?.filter(
     (item) =>
@@ -25,7 +24,7 @@ export default function DigitalStandardsPlaybookPage(props) {
       item.scId === "SUMMARY"
   );
 
-  const displayProjectUpdates = sortedUpdates.map((update) => (
+  const displayProjectUpdates = updatesData.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -11,10 +11,12 @@ import { Heading } from "../../../components/molecules/Heading";
 import TextRender from "../../../components/text_node_renderer/TextRender";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function IntegratedChannelStrategyPage(props) {
   const [pageData] = useState(props.pageData.item);
   const [updatesData] = useState(props.updatesData);
+  const sortedUpdates = sortUpdatesByDate(updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -25,7 +27,7 @@ export default function IntegratedChannelStrategyPage(props) {
     )
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
+  const displayProjectUpdates = sortedUpdates.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/making-easier-get-benefits/index.js
+++ b/pages/projects/making-easier-get-benefits/index.js
@@ -15,8 +15,7 @@ import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function IntegratedChannelStrategyPage(props) {
   const [pageData] = useState(props.pageData.item);
-  const [updatesData] = useState(props.updatesData);
-  const sortedUpdates = sortUpdatesByDate(updatesData);
+  const updatesData = sortUpdatesByDate(props.updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -27,7 +26,7 @@ export default function IntegratedChannelStrategyPage(props) {
     )
   );
 
-  const displayProjectUpdates = sortedUpdates.map((update) => (
+  const displayProjectUpdates = updatesData.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -10,10 +10,12 @@ import { createBreadcrumbs } from "../../../lib/utils/createBreadcrumbs";
 import { Heading } from "../../../components/molecules/Heading";
 import Image from "next/image";
 import stageDictionary from "../../../lib/utils/stageDictionary";
+import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
   const [updatesData] = useState(props.updatesData);
+  const sortedUpdates = sortUpdatesByDate(updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -24,7 +26,7 @@ export default function OasBenefitsEstimator(props) {
     )
   );
 
-  const displayProjectUpdates = updatesData.map((update) => (
+  const displayProjectUpdates = sortedUpdates.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage

--- a/pages/projects/oas-benefits-estimator/index.js
+++ b/pages/projects/oas-benefits-estimator/index.js
@@ -14,8 +14,7 @@ import { sortUpdatesByDate } from "../../../lib/utils/sortUpdatesByDate";
 
 export default function OasBenefitsEstimator(props) {
   const [pageData] = useState(props.pageData.item);
-  const [updatesData] = useState(props.updatesData);
-  const sortedUpdates = sortUpdatesByDate(updatesData);
+  const updatesData = sortUpdatesByDate(props.updatesData);
   const [filteredDictionary] = useState(
     props.dictionary.items.filter(
       (item) =>
@@ -26,7 +25,7 @@ export default function OasBenefitsEstimator(props) {
     )
   );
 
-  const displayProjectUpdates = sortedUpdates.map((update) => (
+  const displayProjectUpdates = updatesData.map((update) => (
     <li key={update.scId} className="list-none ml-0 col-span-12 lg:col-span-4">
       <Card
         showImage


### PR DESCRIPTION
# [Sort updates on project pages by date with most recent on the left (old design)](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=224225)

Sorted project updates by date

## Test Instructions

1. yarn dev
2. navigate to each project page
3. ensure dates are sorted properly

