### PR TITLE
Fix list style on cdcp-apply page

### DIFF
--- a/pages/cdcp-apply.js
+++ b/pages/cdcp-apply.js
@@ -94,12 +94,22 @@ export default function CDCPLanding(props) {
           </div>
           <div className="col-span-12 xl:col-span-8">
             <p>{t("cdcp.toCompleteApplication")}</p>
-            <ul className="mt-5">
-              <li>{t("cdcp.listItems.item1")}</li>
-              <li>{t("cdcp.listItems.item2")}</li>
-              <li>{t("cdcp.listItems.item3")}</li>
-              <li>{t("cdcp.listItems.item4")}</li>
-              <li>{t("cdcp.listItems.item5")}</li>
+            <ul className="list-disc mt-5">
+              <li className="ml-10">
+                <p>{t("cdcp.listItems.item1")}</p>
+              </li>
+              <li className="ml-10">
+                <p>{t("cdcp.listItems.item2")}</p>
+              </li>
+              <li className="ml-10">
+                <p>{t("cdcp.listItems.item3")}</p>
+              </li>
+              <li className="ml-10">
+                <p>{t("cdcp.listItems.item4")}</p>
+              </li>
+              <li className="ml-10">
+                <p>{t("cdcp.listItems.item5")}</p>
+              </li>
             </ul>
             <h2 className="mt-10 mb-10">{t("cdcp.headingH2")}</h2>
             <p>{t("cdcp.clickButtonToApply")}</p>


### PR DESCRIPTION
# [Fix list styles on CDCP Apply landing page](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities?workitem=224988)

Fix list styling on cdcp-apply page

Before:
![Screenshot 2024-07-09 at 11 21 31 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/b146d8d4-7e25-4155-8cc9-a3092de87724)


After:
![Screenshot 2024-07-09 at 11 22 12 AM](https://github.com/DTS-STN/Service-Canada-Labs/assets/31868510/0bbf766a-fc86-4e8e-9b2d-ac3d7ab498c7)

## Test Instructions

1. Navigate to cdcp-apply page
2. See list is formatted properly (20px font-size, indented)
