### PR TITLE
use unoptimized={true} on next/image

### DIFF
--- a/components/fragment_renderer/fragment_components/BasicTextWithImage.js
+++ b/components/fragment_renderer/fragment_components/BasicTextWithImage.js
@@ -15,6 +15,7 @@ export default function BasicTextWithImage({
         <div className="flex justify-center">
           <div className="h-auto">
             <Image
+              unoptimized={true}
               src={src}
               alt={alt}
               width={width}

--- a/components/fragment_renderer/fragment_components/ImageFragment.js
+++ b/components/fragment_renderer/fragment_components/ImageFragment.js
@@ -4,6 +4,7 @@ export default function ImageFragment(props) {
   return (
     <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
       <Image
+        unoptimized={true}
         id={props.scId}
         src={
           props.locale === "en"

--- a/components/fragment_renderer/fragment_components/ImageVerticalLineContent.js
+++ b/components/fragment_renderer/fragment_components/ImageVerticalLineContent.js
@@ -17,6 +17,7 @@ export default function ImageVerticalLineContent({
       <div className="grid grid-cols-12 gap-x-6 mb-9">
         <div className="mb-6 object-fill col-span-12 row-start-1 xl:row-start-1 xl:col-span-8">
           <Image
+            unoptimized={true}
             src={src}
             alt={alt}
             height={height}

--- a/components/fragment_renderer/fragment_components/ImageWithCollapse.js
+++ b/components/fragment_renderer/fragment_components/ImageWithCollapse.js
@@ -15,6 +15,7 @@ export default function ImageWithCollapse({
   return (
     <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
       <Image
+        unoptimized={true}
         id={id}
         src={src}
         alt={alt}

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -30,6 +30,7 @@ export const Card = (props) => {
         {props.showImage ? (
           <div className="h-[208px] flex justify-center">
             <Image
+              unoptimized={true}
               src={props.imgSrc}
               alt={props.imgAlt}
               className="object-contain"

--- a/components/organisms/Feedback.js
+++ b/components/organisms/Feedback.js
@@ -46,6 +46,7 @@ function Feedback() {
       {isSubmitted && (
         <div className="flex gap-5 items-center">
           <Image
+            unoptimized={true}
             src="/success_img.svg"
             alt=""
             width={25}

--- a/pages/projects/[projectId]/index.js
+++ b/pages/projects/[projectId]/index.js
@@ -115,6 +115,7 @@ export default function ProjectPage({
               <div className="flex justify-center">
                 <div className="object-fill max-w-350px">
                   <Image
+                    unoptimized={true}
                     src={
                       locale === "en"
                         ? projectData.scSocialMediaImageEn._publishUrl


### PR DESCRIPTION
Image optimization is failing consistently and returning 500 errors from the server. There seems to be an issue in the dependency tree but after some testing the issue has been difficult to pinpoint.

For the time being, image optimization will be deactivated until more investigation can be made into the issue.

## Test Instructions

1. Navigate to /en/home
2. See that images render properly
3. Navigate to /en/projects
4. See that images render properly
