### PR TITLE
Separate Build and Push stages in prod Azure pipeline

### DIFF
--- a/AzurePipelines/prod-test-build-and-push.yml
+++ b/AzurePipelines/prod-test-build-and-push.yml
@@ -88,60 +88,12 @@ stages:
               artifact: "cypress-videos"
             condition: always()
 
-  - stage: SecurityTest
-    displayName: Security Testing
-    dependsOn: Build # Run after build since we need the app running
-    jobs:
-      - job: OWASPZapTest
-        displayName: OWASP ZAP Security Tests
-        pool:
-          vmImage: $(vmImageName)
-        steps:
-          # Start the application container
-          - script: |
-              docker pull $(azureContainerRegistry.domain)/$(azureContainerRegistry.repository):$(tag)
-              docker run -d -p 3000:3000 $(azureContainerRegistry.domain)/$(azureContainerRegistry.repository):$(tag)
-            displayName: Start Application Container
-
-          # Run ZAP Baseline Scan
-          - task: owaspzap@1
-            inputs:
-              aggressivemode: false # Set to true for more thorough but slower scan
-              threshold: $(ZAP_THRESHOLD)
-              port: 3000
-              targeturl: $(ZAP_TARGET_URL)
-              scantype: "targetedScan"
-              contextpath: "$(System.DefaultWorkingDirectory)/zap"
-              reportfilename: "OWASP-ZAP-Report.html"
-              reportformat: "html"
-              enableVerifications: true
-              scantimeout: $(ZAP_TIMEOUT)
-              failonhigh: true
-              failonmedium: false
-              scanningmode: "targeted"
-
-          # Publish ZAP test results
-          - task: PublishPipelineArtifact@1
-            displayName: "Publish ZAP Results"
-            inputs:
-              targetPath: "$(System.DefaultWorkingDirectory)/zap"
-              artifact: "zap-security-report"
-            condition: always()
-
-          # Convert ZAP results to JUnit format for better visualization
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFormat: "JUnit"
-              testResultsFiles: "**/zap-report.xml"
-              mergeTestResults: true
-              testRunTitle: "OWASP ZAP Security Tests"
-            condition: always()
-
   - stage: Build
-    displayName: Build and Push to ACR
+    displayName: Build Container
+    dependsOn: Test
     jobs:
       - job: Build
-        displayName: Build and Push Container
+        displayName: Build Container
         pool:
           vmImage: $(vmImageName)
         steps:
@@ -178,6 +130,70 @@ stages:
                 --build-arg ENVIRONMENT=$(ENVIRONMENT)
                 --build-arg NOTIFY_API_KEY=$(NOTIFY_API_KEY)
                 --build-arg NOTIFY_FEEDBACK_TEMPLATE_ID=$(NOTIFY_FEEDBACK_TEMPLATE_ID)
+
+  - stage: SecurityTest
+    displayName: Security Testing
+    dependsOn: Build
+    jobs:
+      - job: OWASPZapTest
+        displayName: OWASP ZAP Security Tests
+        pool:
+          vmImage: $(vmImageName)
+        steps:
+          # Start the application container
+          - script: |
+              docker pull $(azureContainerRegistry.domain)/$(azureContainerRegistry.repository):$(tag)
+              docker run -d -p 3000:3000 $(azureContainerRegistry.domain)/$(azureContainerRegistry.repository):$(tag)
+            displayName: Start Application Container
+
+          # Use OWASP ZAP Scanner Task
+          - task: Zap@1
+            inputs:
+              aggressivemode: false
+              threshold: $(ZAP_THRESHOLD)
+              port: 3000
+              targeturl: $(ZAP_TARGET_URL)
+              scantype: "targetedScan"
+              contextpath: "$(System.DefaultWorkingDirectory)/zap"
+              reportfilename: "OWASP-ZAP-Report.html"
+              reportformat: "html"
+              enableVerifications: true
+              scantimeout: $(ZAP_TIMEOUT)
+              failonhigh: true
+              failonmedium: false
+              scanningmode: "targeted"
+
+          # Publish ZAP test results
+          - task: PublishPipelineArtifact@1
+            displayName: "Publish ZAP Results"
+            inputs:
+              targetPath: "$(System.DefaultWorkingDirectory)/zap"
+              artifact: "zap-security-report"
+            condition: always()
+
+          # Convert ZAP results to JUnit format for better visualization
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: "JUnit"
+              testResultsFiles: "**/zap-report.xml"
+              mergeTestResults: true
+              testRunTitle: "OWASP ZAP Security Tests"
+            condition: always()
+
+  - stage: Push
+    displayName: Push to ACR
+    dependsOn: SecurityTest
+    jobs:
+      - job: PushContainer
+        displayName: Push Container to ACR
+        pool:
+          vmImage: $(vmImageName)
+        steps:
+          - task: Docker@2
+            inputs:
+              containerRegistry: "$(azureContainerRegistry.name)"
+              repository: "$(azureContainerRegistry.repository)"
+              command: "login"
 
           - task: Docker@2
             inputs:


### PR DESCRIPTION
- Introduced a new Build stage to build the Docker container with necessary build arguments.
- Updated the SecurityTest stage to depend on the new Build stage.
- Created new Push stage.
- Removed redundant Docker pull and build steps from the Push stage, streamlining the pipeline.
