### PR TITLE
Update Azure Pipelines YAML to change Docker command from build to buildAndPush for image creation (#1158

### DIFF
--- a/AzurePipelines/prod-test-build-and-push.yml
+++ b/AzurePipelines/prod-test-build-and-push.yml
@@ -35,10 +35,11 @@ stages:
             displayName: Pull latest for layer caching
             continueOnError: true
           - task: Docker@2
+            displayName: Build and push image
             inputs:
               containerRegistry: "$(azureContainerRegistry.name)"
               repository: "$(azureContainerRegistry.repository)"
-              command: "build"
+              command: buildAndPush
               Dockerfile: "./Dockerfile"
               tags: |
                 $(tag)


### PR DESCRIPTION
- Modified the Docker task in the prod-test-build-and-push.yml to use the buildAndPush command, ensuring the image is built and pushed in a single step.
- Added a display name for clarity in the pipeline execution logs
