### PR TITLE
Refactor Docker command in Azure Pipelines to separate build and push steps

### DIFF
--- a/AzurePipelines/prod-test-build-and-push.yml
+++ b/AzurePipelines/prod-test-build-and-push.yml
@@ -35,11 +35,10 @@ stages:
             displayName: Pull latest for layer caching
             continueOnError: true
           - task: Docker@2
-            displayName: Build and push image
             inputs:
               containerRegistry: "$(azureContainerRegistry.name)"
               repository: "$(azureContainerRegistry.repository)"
-              command: buildAndPush
+              command: "build"
               Dockerfile: "./Dockerfile"
               tags: |
                 $(tag)


### PR DESCRIPTION
- Changed the Docker task command from 'buildAndPush' to 'build' in the prod-test-build-and-push.yml file.
- This modification allows for more granular control over the image building process, separating the build and push actions.