### PR TITLE
refactor: Switch from Static to Server-Side Rendering for project and article pages

### DIFF
--- a/pages/projects/[projectId]/[articleId].js
+++ b/pages/projects/[projectId]/[articleId].js
@@ -158,36 +158,11 @@ export default function ArticlePage({ ...props }) {
 }
 
 /**
- * Generate static paths for all articles
- * Required for Next.js dynamic routing
- * Creates paths for both English and French versions of each article
- */
-export async function getStaticPaths() {
-  const articleIdLabel = "articleId";
-  const projectIdLabel = "projectId";
-  // Fetch all projects aarticles from AEM
-  const { data: updatesData } = await fetch(
-    `${process.env.AEM_BASE_URL}/getSclAllUpdatesV2${process.env.AEM_CONTENT_FOLDER}`
-  ).then((res) => res.json());
-
-  // Generate paths array for all articles in both languages
-  const paths = getAllPathParams(
-    [articleIdLabel, projectIdLabel],
-    updatesData.sclabsPageV1List.items
-  );
-
-  return {
-    paths,
-    fallback: "blocking", // Show loading state for new pages being generated
-  };
-}
-
-/**
- * Fetch and prepare data for page rendering at build time
+ * Fetch and prepare data for page rendering at request time
  * Handles data fetching, language selection, and 404 cases
  * @param {Object} context - Contains locale and URL parameters
  */
-export const getStaticProps = async ({ locale, params }) => {
+export const getServerSideProps = async ({ locale, params }) => {
   const articleIdLabel = "articleId";
   // Fetch all articles data from AEM
   const { data: updatesData } = await fetch(
@@ -231,7 +206,5 @@ export const getStaticProps = async ({ locale, params }) => {
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null, // Analytics configuration
       ...(await serverSideTranslations(locale, ["common", "vc"])), // Load translations
     },
-    // Enable Incremental Static Regeneration if configured
-    revalidate: process.env.ISR_ENABLED === "true" ? 600 : false,
   };
 };

--- a/pages/projects/[projectId]/index.js
+++ b/pages/projects/[projectId]/index.js
@@ -251,30 +251,11 @@ export default function ProjectPage({
 }
 
 /**
- * Generate static paths for all project pages
- * Similar structure to article pages for consistency
+ * Fetch and prepare data for page rendering at request time
+ * Handles data fetching, language selection, and 404 cases
+ * @param {Object} context - Contains locale and URL parameters
  */
-export async function getStaticPaths() {
-  const idLabel = "projectId";
-  // Fetch main page content from AEM
-  const { data } = await fetch(
-    `https://www.canada.ca/graphql/execute.json/decd-endc/getSclAllProjectsV2${process.env.AEM_CONTENT_FOLDER}`
-  ).then((res) => res.json());
-
-  // Generate paths array for all projects in both languages
-  const paths = getAllPathParams([idLabel], data.sclabsPageV1List.items);
-  // Extract the project ID from the full path
-  paths.map(
-    (path) => (path.params[idLabel] = path.params[idLabel].split("/").at(-1))
-  );
-
-  return {
-    paths,
-    fallback: "blocking",
-  };
-}
-
-export const getStaticProps = async ({ locale, params }) => {
+export const getServerSideProps = async ({ locale, params }) => {
   const idLabel = "projectId";
   // Fetch main page content from AEM
 
@@ -318,7 +299,5 @@ export const getStaticProps = async ({ locale, params }) => {
       // Include common translations
       ...(await serverSideTranslations(locale, ["common"])),
     },
-    // Enable ISR if configured in environment
-    revalidate: process.env.ISR_ENABLED === "true" ? 600 : false,
   };
 };


### PR DESCRIPTION
Remove static generation methods (getStaticPaths and getStaticProps) and replace with getServerSideProps to enable dynamic server-side rendering. Removed Incremental Static Regeneration (ISR) configuration.
