### PR TITLE
refactor: Revert to Static Site Generation (SSG) for project and article pages

### DIFF
--- a/pages/projects/[projectId]/[articleId].js
+++ b/pages/projects/[projectId]/[articleId].js
@@ -162,11 +162,36 @@ export default function ArticlePage({ ...props }) {
 }
 
 /**
- * Fetch and prepare data for page rendering at request time
+ * Generate static paths for all articles
+ * Required for Next.js dynamic routing
+ * Creates paths for both English and French versions of each article
+ */
+export async function getStaticPaths() {
+  const articleIdLabel = "articleId";
+  const projectIdLabel = "projectId";
+  // Fetch all projects aarticles from AEM
+  const { data: updatesData } = await fetch(
+    `${process.env.AEM_BASE_URL}/getSclAllUpdatesV2${process.env.AEM_CONTENT_FOLDER}`
+  ).then((res) => res.json());
+
+  // Generate paths array for all articles in both languages
+  const paths = getAllPathParams(
+    [articleIdLabel, projectIdLabel],
+    updatesData.sclabsPageV1List.items
+  );
+
+  return {
+    paths,
+    fallback: "blocking", // Show loading state for new pages being generated
+  };
+}
+
+/**
+ * Fetch and prepare data for page rendering at build time
  * Handles data fetching, language selection, and 404 cases
  * @param {Object} context - Contains locale and URL parameters
  */
-export const getServerSideProps = async ({ locale, params }) => {
+export const getStaticProps = async ({ locale, params }) => {
   const articleIdLabel = "articleId";
   // Fetch all articles data from AEM
   const { data: updatesData } = await fetch(
@@ -210,5 +235,7 @@ export const getServerSideProps = async ({ locale, params }) => {
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null, // Analytics configuration
       ...(await serverSideTranslations(locale, ["common", "vc"])), // Load translations
     },
+    // Enable Incremental Static Regeneration if configured
+    revalidate: process.env.ISR_ENABLED === "true" ? 600 : false,
   };
 };

--- a/services/AEMService.js
+++ b/services/AEMService.js
@@ -22,7 +22,8 @@ class AEMService {
     headers.append("Content-Type", "application/json")
     headers.append("User-Agent", "sc-labs/1.1.3");
 
-    const query = require(`../graphql/queries/${fragId}.graphql`).loc.source.body
+    const graphqlModule = await import(`../graphql/queries/${fragId}.graphql`);
+    const query = graphqlModule.default.loc.source.body;
 
     let error, data;
     try {


### PR DESCRIPTION
Implement static generation methods (getStaticPaths and getStaticProps) for project and article pages:
- Add getStaticPaths to generate static paths for both pages
- Replace getServerSideProps with getStaticProps
- Restore Incremental Static Regeneration (ISR) with 10-minute revalidation
- Update AEMService to use dynamic import for GraphQL queries

