### PR TITLE
fix: Improve project query parameter matching in updates page

### DIFF
--- a/pages/updates.js
+++ b/pages/updates.js
@@ -132,8 +132,9 @@ export default function UpdatesPage(props) {
       const routerQuery =
         props.locale === "en" ? router.query.project : router.query.projet;
       // Find matching options for the query parameter
+      const routerQueryFormatted = routerQuery.replaceAll("-", " ");
       const selectedOptionsFromQueryString = options.filter(
-        (option) => option.label === routerQuery
+        (option) => option.label === routerQueryFormatted
       );
       console.log(
         "Selected options from query string:",


### PR DESCRIPTION
Modify the updates page to handle project query parameters with hyphens by replacing them with spaces before filtering options.
