### PR TITLE
Upgrading OWASP ZAP version to 0.12.0 and checkout to v4

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker Build
         run: docker build . --build-arg AEM_GRAPHQL_ENDPOINT=${{secrets.AEM_GRAPHQL_ENDPOINT}} --build-arg AEM_BASE_URL=${{secrets.AEM_BASE_URL}} --build-arg AEM_CONTENT_FOLDER=${{secrets.AEM_CONTENT_FOLDER}} -t sc-labs
@@ -30,7 +30,7 @@ jobs:
           AEM_CONTENT_FOLDER: ${{ secrets.AEM_CONTENT_FOLDER }}
 
       - name: OWASP ZAP FULL Scan
-        uses: zaproxy/action-full-scan@v0.4.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: "http://localhost:3000"
           fail_action: "false"


### PR DESCRIPTION
# Updating GH Workflow versions (OWASP ZAP and checkout)

As part of fixing the OWASP ZAP action, the docker pull request on the ZAP action isn't functioning. While looking into this I noticed that the versions were out of date as part of this action, this is just a patch to update them to the current version.

## Test Instructions

Unfortunately, none, this is a github specific workflow update.

## Definition of Done

- The workflow action versions have been updated to 0.12.0 (OWASP ZAP) and v4(checkout)
