### PR TITLE
feat: Add survey link to SurveyPopup component

### DIFF
--- a/components/molecules/SurveyPopup.js
+++ b/components/molecules/SurveyPopup.js
@@ -12,6 +12,7 @@ export const SurveyPopup = ({
   openButtonLabel,
   closeButtonLabel,
   optionsGroupLabel,
+  surveyLink,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useTranslation("common");
@@ -117,12 +118,15 @@ export const SurveyPopup = ({
                 >
                   {noThanksText || t("surveyPopup.noThanksButton")}
                 </button>
-                <button
+                <a
                   ref={takeSurveyRef}
-                  className="px-4 py-2 bg-white text-custom-blue-dark hover:bg-gray-100 transition-colors rounded focus:outline-none focus:ring-2 focus:ring-white"
+                  href={surveyLink || t("surveyPopup.surveyLink")}
+                  className="px-4 py-2 bg-white font-body text-custom-blue-dark text-center hover:bg-gray-100 transition-colors rounded focus:outline-none focus:ring-2 focus:ring-white inline-block"
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {takeSurveyText || t("surveyPopup.takeSurveyButton")}
-                </button>
+                </a>
               </div>
             </div>
           </div>
@@ -169,6 +173,10 @@ SurveyPopup.propTypes = {
    * ARIA label for the options group
    */
   optionsGroupLabel: PropTypes.string,
+  /**
+   * Link to the survey
+   */
+  surveyLink: PropTypes.string,
 };
 
 export default SurveyPopup;

--- a/components/molecules/SurveyPopup.test.js
+++ b/components/molecules/SurveyPopup.test.js
@@ -19,7 +19,8 @@ jest.mock("next-i18next", () => ({
         "surveyPopup.optionsGroupLabel": "Survey options",
         "surveyPopup.noThanksButton": "No thanks",
         "surveyPopup.takeSurveyButton": "Take the survey",
-        "surveyPopup.surveyLink": "https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev"
+        "surveyPopup.surveyLink":
+          "https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev",
       }[key]),
   }),
 }));
@@ -57,9 +58,12 @@ describe("SurveyPopup", () => {
       screen.getByRole("button", { name: /No thanks/i })
     ).toBeInTheDocument();
     const surveyLink = screen.getByText(/Take the survey/i);
-    expect(surveyLink).toHaveAttribute('href', 'https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev');
-    expect(surveyLink).toHaveAttribute('target', '_blank');
-    expect(surveyLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(surveyLink).toHaveAttribute(
+      "href",
+      "https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev"
+    );
+    expect(surveyLink).toHaveAttribute("target", "_blank");
+    expect(surveyLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it('collapses when "No thanks" is clicked', () => {

--- a/components/molecules/SurveyPopup.test.js
+++ b/components/molecules/SurveyPopup.test.js
@@ -19,6 +19,7 @@ jest.mock("next-i18next", () => ({
         "surveyPopup.optionsGroupLabel": "Survey options",
         "surveyPopup.noThanksButton": "No thanks",
         "surveyPopup.takeSurveyButton": "Take the survey",
+        "surveyPopup.surveyLink": "https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev"
       }[key]),
   }),
 }));
@@ -55,9 +56,10 @@ describe("SurveyPopup", () => {
     expect(
       screen.getByRole("button", { name: /No thanks/i })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Take the survey/i })
-    ).toBeInTheDocument();
+    const surveyLink = screen.getByText(/Take the survey/i);
+    expect(surveyLink).toHaveAttribute('href', 'https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev');
+    expect(surveyLink).toHaveAttribute('target', '_blank');
+    expect(surveyLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('collapses when "No thanks" is clicked', () => {
@@ -140,7 +142,7 @@ describe("SurveyPopup", () => {
         screen.getByRole("button", { name: customText.noThanksText })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: customText.takeSurveyText })
+        screen.getByRole("link", { name: customText.takeSurveyText })
       ).toBeInTheDocument();
       expect(screen.getByRole("group")).toHaveAttribute(
         "aria-label",
@@ -168,7 +170,7 @@ describe("SurveyPopup", () => {
         screen.getByRole("button", { name: "No thanks" })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Take the survey" })
+        screen.getByRole("link", { name: "Take the survey" })
       ).toBeInTheDocument();
     });
 
@@ -193,7 +195,7 @@ describe("SurveyPopup", () => {
         screen.getByRole("button", { name: customText.noThanksText })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Take the survey" })
+        screen.getByRole("link", { name: "Take the survey" })
       ).toBeInTheDocument();
     });
   });

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -121,6 +121,7 @@
     "description": "You can help shape this website too. Take a few minutes to tell us about your experience.",
     "optionsGroupLabel": "Survey options",
     "noThanksButton": "No thanks",
-    "takeSurveyButton": "Take the survey"
+    "takeSurveyButton": "Take the survey",
+    "surveyLink": "https://forms-formulaires.alpha.canada.ca/en/id/cm7umabys007nx268kfkobpev"
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -121,6 +121,7 @@
     "description": "Vous pouvez aussi contribuer à façonner ce site Web. Prenez quelques minutes pour nous parler de votre expérience.",
     "optionsGroupLabel": "Options du sondage",
     "noThanksButton": "Non merci",
-    "takeSurveyButton": "Répondre au sondage"
+    "takeSurveyButton": "Répondre au sondage",
+    "surveyLink": "https://forms-formulaires.alpha.canada.ca/fr/id/cm7umabys007nx268kfkobpev"
   }
 }


### PR DESCRIPTION
- Introduced a new prop `surveyLink` to the SurveyPopup component for customizable survey URLs.
- Updated the component to render the survey link as an anchor tag for better accessibility and user experience.
- Modified localization files to include the survey link in both English and French.
