### PR TITLE
feat: Enhance TextContent component with layout options and update styles

### DIFF
--- a/components/fragment_renderer/FragmentRender.stories.js
+++ b/components/fragment_renderer/FragmentRender.stories.js
@@ -1265,6 +1265,7 @@ TextContent.args = {
           },
         ],
       },
+      scLabLayout: "default",
     },
   ],
 };

--- a/components/fragment_renderer/fragment_components/TextContent.js
+++ b/components/fragment_renderer/fragment_components/TextContent.js
@@ -1,11 +1,30 @@
 import TextRender from "../../text_node_renderer/TextRender";
 
-export default function TextContent({ data, excludeH1 }) {
-  return (
-    <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
-      <div className="col-span-12 lg:col-span-7">
-        <TextRender data={data} excludeH1={excludeH1} />
-      </div>
-    </div>
-  );
+export default function TextContent({ data, excludeH1, layout }) {
+  switch (layout) {
+    case "default":
+      return (
+        <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
+          <div className="col-span-12 lg:col-span-7">
+            <TextRender data={data} excludeH1={excludeH1} />
+          </div>
+        </div>
+      );
+    case "quote":
+      return (
+        <div className="layout-container grid grid-cols-12 gap-x-6 my-12">
+          <div className="col-span-12 xl:col-span-7">
+            <div className="speech-bubble-full-width">
+              <div className="speech-bubble-top-full-width">
+                <blockquote className="speech-bubble-quote">
+                  <TextRender data={data} excludeH1={excludeH1} />
+                </blockquote>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    default:
+      break;
+  }
 }

--- a/components/fragment_renderer/fragment_components/TextContent.stories.js
+++ b/components/fragment_renderer/fragment_components/TextContent.stories.js
@@ -23,4 +23,23 @@ Default.args = {
       ],
     },
   ],
+  layout: "default",
+};
+
+export const Quote = Template.bind({});
+
+Quote.args = {
+  data: [
+    {
+      nodeType: "paragraph",
+      content: [
+        {
+          nodeType: "text",
+          value:
+            "Every week, our product team meets for Feedback Friday to sort through all the new survey responses. We look at the ratings and comments people shared with us about their experience. ",
+        },
+      ],
+    },
+  ],
+  layout: "quote",
 };

--- a/components/fragment_renderer/fragment_components/TextContent.test.js
+++ b/components/fragment_renderer/fragment_components/TextContent.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import TextContent from "./TextContent";
-import { Default } from "./TextContent.stories.js";
+import { Default, Quote } from "./TextContent.stories.js";
 import { axe, toHaveNoViolations } from "jest-axe";
 
 expect.extend(toHaveNoViolations);
@@ -11,6 +11,15 @@ describe("TextContent", () => {
     const { container } = render(<TextContent {...Default.args} />);
     expect(screen.getByText((content) => content.startsWith("Every week")))
       .toBeInTheDocument;
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test("renders TextContent component with quote layout", async () => {
+    const { container } = render(<TextContent {...Quote.args} />);
+    expect(screen.getByText((content) => content.startsWith("Every week")))
+      .toBeInTheDocument;
+    expect(container.querySelector('.speech-bubble-quote')).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/components/fragment_renderer/fragment_components/TextContent.test.js
+++ b/components/fragment_renderer/fragment_components/TextContent.test.js
@@ -19,7 +19,7 @@ describe("TextContent", () => {
     const { container } = render(<TextContent {...Quote.args} />);
     expect(screen.getByText((content) => content.startsWith("Every week")))
       .toBeInTheDocument;
-    expect(container.querySelector('.speech-bubble-quote')).toBeInTheDocument();
+    expect(container.querySelector(".speech-bubble-quote")).toBeInTheDocument();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/components/fragment_renderer/mappers/TextContentMapper.js
+++ b/components/fragment_renderer/mappers/TextContentMapper.js
@@ -2,23 +2,15 @@ import { getLocalizedContent } from "../utils/localeUtils";
 import { fragmentValidators } from "../utils/validation";
 
 const mapDefaultLayout = (fragmentData, locale, excludeH1) => ({
-  data: getLocalizedContent(
-    fragmentData,
-    locale,
-    "scContentEn",
-    "scContentFr"
-  ).json,
+  data: getLocalizedContent(fragmentData, locale, "scContentEn", "scContentFr")
+    .json,
   layout: "default",
   excludeH1,
 });
 
 const mapQuoteLayout = (fragmentData, locale, excludeH1) => ({
-  data: getLocalizedContent(
-    fragmentData,
-    locale,
-    "scContentEn",
-    "scContentFr"
-  ).json,
+  data: getLocalizedContent(fragmentData, locale, "scContentEn", "scContentFr")
+    .json,
   layout: "quote",
   excludeH1,
 });

--- a/components/fragment_renderer/mappers/TextContentMapper.js
+++ b/components/fragment_renderer/mappers/TextContentMapper.js
@@ -1,17 +1,38 @@
 import { getLocalizedContent } from "../utils/localeUtils";
 import { fragmentValidators } from "../utils/validation";
 
+const mapDefaultLayout = (fragmentData, locale, excludeH1) => ({
+  data: getLocalizedContent(
+    fragmentData,
+    locale,
+    "scContentEn",
+    "scContentFr"
+  ).json,
+  layout: "default",
+  excludeH1,
+});
+
+const mapQuoteLayout = (fragmentData, locale, excludeH1) => ({
+  data: getLocalizedContent(
+    fragmentData,
+    locale,
+    "scContentEn",
+    "scContentFr"
+  ).json,
+  layout: "quote",
+  excludeH1,
+});
+
 export default function TextContentMapper(fragmentData, locale, excludeH1) {
   // Validate fragment data
   fragmentValidators["SCLabs-Content-v1"](fragmentData);
 
-  return {
-    data: getLocalizedContent(
-      fragmentData,
-      locale,
-      "scContentEn",
-      "scContentFr"
-    ).json,
-    excludeH1,
+  const layoutMappers = {
+    default: () => mapDefaultLayout(fragmentData, locale, excludeH1),
+    "quote-vertical-line-content": () =>
+      mapQuoteLayout(fragmentData, locale, excludeH1),
   };
+
+  const mapper = layoutMappers[fragmentData.scLabLayout];
+  return mapper ? mapper() : null;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,6 @@
 @tailwind utilities;
 @tailwind variants;
 
-
 html {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -43,7 +42,7 @@ html {
   h4 {
     @apply text-mobileh4;
   }
-  h5{
+  h5 {
     @apply text-mobileh5;
   }
   p {
@@ -70,7 +69,7 @@ html {
     h4 {
       @apply text-h4;
     }
-    h5{
+    h5 {
       @apply text-h5;
     }
     p {
@@ -96,7 +95,7 @@ html {
     margin-top: 2rem;
   }
   p + ul {
-    margin-top: .5rem;
+    margin-top: 0.5rem;
   }
 }
 
@@ -404,7 +403,6 @@ html {
   }
 }
 
-
 .help-icon {
   fill: #2b4380;
 }
@@ -576,7 +574,25 @@ blockquote.speech-bubble-quote > p {
   margin-left: 10px;
 }
 
+.speech-bubble-full-width {
+  position: relative;
+  background: rgb(119, 136, 164);
+  border-radius: 0.6em;
+  padding: 4px;
+  max-width: 100%;
+  margin-bottom: 20px;
+  margin-top: 10px;
+  margin-left: 10px;
+}
+
 .speech-bubble-top {
+  background: rgb(78, 92, 125);
+  border-radius: 0.6em;
+  padding: 15px;
+  margin: auto;
+}
+
+.speech-bubble-top-full-width {
   background: rgb(78, 92, 125);
   border-radius: 0.6em;
   padding: 15px;
@@ -597,11 +613,39 @@ blockquote.speech-bubble-quote > p {
   margin-bottom: -20px;
 }
 
+.speech-bubble-full-width:after {
+  content: "";
+  position: absolute;
+  bottom: 5%;
+  left: 10%;
+  width: 0;
+  height: 0;
+  border: 20px solid transparent;
+  border-top-color: rgb(78, 92, 125);
+  border-bottom: 0;
+  margin-left: -20px;
+  margin-bottom: -20px;
+}
+
 .speech-bubble-top:after {
   content: "";
   position: absolute;
   bottom: 0;
   left: 20%;
+  width: 0;
+  height: 0;
+  border: 20px solid transparent;
+  border-top-color: rgb(119, 136, 164);
+  border-bottom: 0;
+  margin-left: -20px;
+  margin-bottom: -20px;
+}
+
+.speech-bubble-top-full-width:after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 10%;
   width: 0;
   height: 0;
   border: 20px solid transparent;
@@ -635,9 +679,9 @@ blockquote.speech-bubble-quote > p {
 }
 
 .btn-primary {
-  @apply font-header font-normal text-multi-neutrals-white bg-multi-blue-blue70 px-[16px] py-[8px] text-btnother
+  @apply font-header font-normal text-multi-neutrals-white bg-multi-blue-blue70 px-[16px] py-[8px] text-btnother;
 }
 
 .btn-link {
-  @apply font-header font-normal text-btnother rounded-[4px] py-[6px] px-[14px]
+  @apply font-header font-normal text-btnother rounded-[4px] py-[6px] px-[14px];
 }


### PR DESCRIPTION
* Added support for "quote" layout in TextContent component, allowing for different presentation styles.
* Updated TextContent stories to include examples for both "default" and "quote" layouts.
* Modified TextContentMapper to handle layout selection based on fragment data.
* Introduced new CSS styles for speech bubble presentation in the quote layout.
* Updated tests to validate rendering of TextContent with the new quote layout.
