### PR TITLE
refactor: Rename layout key for quote in TextContentMapper

### DIFF
--- a/components/fragment_renderer/mappers/TextContentMapper.js
+++ b/components/fragment_renderer/mappers/TextContentMapper.js
@@ -21,8 +21,7 @@ export default function TextContentMapper(fragmentData, locale, excludeH1) {
 
   const layoutMappers = {
     default: () => mapDefaultLayout(fragmentData, locale, excludeH1),
-    "quote-vertical-line-content": () =>
-      mapQuoteLayout(fragmentData, locale, excludeH1),
+    quote: () => mapQuoteLayout(fragmentData, locale, excludeH1),
   };
 
   const mapper = layoutMappers[fragmentData.scLabLayout];


### PR DESCRIPTION
* Changed the layout key from "quote-vertical-line-content" to "quote".
* This update aligns with the recent enhancements made to the TextContent component's layout options.
