### PR TITLE
fix: Update TextContentMapper to handle default layout case

### DIFF
--- a/components/fragment_renderer/mappers/TextContentMapper.js
+++ b/components/fragment_renderer/mappers/TextContentMapper.js
@@ -25,5 +25,5 @@ export default function TextContentMapper(fragmentData, locale, excludeH1) {
   };
 
   const mapper = layoutMappers[fragmentData.scLabLayout];
-  return mapper ? mapper() : null;
+  return mapper ? mapper() : mapDefaultLayout(fragmentData, locale, excludeH1);
 }


### PR DESCRIPTION
* Modified TextContentMapper to return a default layout when no specific layout is found for the fragment data. This change ensures that the component can gracefully handle undefined layout configurations.
