### PR TITLE
fix: Update API endpoints for fetching project and dictionary data 

### DIFF
--- a/pages/projects.js
+++ b/pages/projects.js
@@ -208,7 +208,7 @@ export default function ProjectsPage(props) {
 export const getStaticProps = async ({ locale }) => {
   // Fetch main page content from AEM
   const { data: pageData } = await fetch(
-    `${process.env.AEM_BASE_URL}/getSclProjectsV2`
+    `${process.env.AEM_BASE_URL}/getSclProjectsPageV1${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   // Fetch all projects data
@@ -218,7 +218,7 @@ export const getStaticProps = async ({ locale }) => {
 
   // Fetch translation dictionary
   const { data: dictionary } = await fetch(
-    `${process.env.AEM_BASE_URL}/getSclDictionaryV1`
+    `${process.env.AEM_BASE_URL}/getSclDictionaryV2${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   // Return props for page rendering

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -17,7 +17,7 @@ import { useTranslation } from "next-i18next";
  */
 export default function ProjectsPage(props) {
   // Extract data from props
-  const pageData = props.pageData?.item; // Page content from AEM
+  const pageData = props.pageData; // Page content from AEM
   const projectsData = props.projectsData; // All projects data
   const dictionary = props.dictionary; // Translation dictionary
   // State for managing selected filter options
@@ -226,7 +226,7 @@ export const getStaticProps = async ({ locale }) => {
     props: {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL ?? null,
-      pageData: pageData.sclabsPageV1ByPath,
+      pageData: pageData.sclabsPageV1List.items[0],
       projectsData: projectsData.sclabsPageV1List.items,
       dictionary: dictionary.dictionaryV1List.items,
       // Include translations for common terms and multiSelect component

--- a/pages/projects/[projectId]/[articleId].js
+++ b/pages/projects/[projectId]/[articleId].js
@@ -201,7 +201,7 @@ export const getStaticProps = async ({ locale, params }) => {
   ).then((res) => res.json());
   // Fetch translation dictionary
   const { data: dictionary } = await fetch(
-    `https://www.canada.ca/graphql/execute.json/decd-endc/getSclDictionaryV1`
+    `${process.env.AEM_BASE_URL}/getSclDictionaryV2${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   const pages = updatesData.sclabsPageV1List.items;

--- a/pages/projects/[projectId]/index.js
+++ b/pages/projects/[projectId]/index.js
@@ -290,12 +290,12 @@ export const getStaticProps = async ({ locale, params }) => {
   // Fetch main page content from AEM
 
   const { data: allProjectsData } = await fetch(
-    `https://www.canada.ca/graphql/execute.json/decd-endc/getSclAllProjectsV2${process.env.AEM_CONTENT_FOLDER}`
+    `${process.env.AEM_BASE_URL}/getSclAllProjectsV2${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   // Fetch translation dictionary
   const { data: dictionary } = await fetch(
-    `https://www.canada.ca/graphql/execute.json/decd-endc/getSclDictionaryV1`
+    `${process.env.AEM_BASE_URL}/getSclDictionaryV2${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   const pages = allProjectsData.sclabsPageV1List.items;

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -227,7 +227,7 @@ export const getStaticProps = async ({ locale }) => {
 
   // Fetch translation dictionary
   const { data: dictionary } = await fetch(
-    `${process.env.AEM_BASE_URL}/getSclDictionaryV1`
+    `${process.env.AEM_BASE_URL}/getSclDictionaryV2${process.env.AEM_CONTENT_FOLDER}`
   ).then((res) => res.json());
 
   // Return props for page rendering


### PR DESCRIPTION
* Changed API endpoint for fetching project data from `getSclProjectsV2` to `getSclProjectsPageV1`.
* Updated dictionary fetching endpoint from `getSclDictionaryV1` to `getSclDictionaryV2` across multiple files.
* Ensured consistency in using the environment variable for base URL and content folder in all relevant fetch calls.